### PR TITLE
Makefile, docker-comopose.yml: Added SSL self signed certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 BRANCH:=$(shell git branch| grep \*| cut -d ' ' -f2)
 export TEST = 0
 export HOST_IP_ADDRESS=$(shell ifconfig docker0 | sed -En 's/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
+SSL_CERT_PATH:=data/keys/ssl
 
 .init:
 	@$(call msg,"Initializing ...");
@@ -54,6 +55,11 @@ endif
 		mkdir -p data/keys; \
 		openssl genpkey -algorithm RSA -out data/keys/private.pem -pkeyopt rsa_keygen_bits:2048; \
 		openssl rsa -pubout -in data/keys/private.pem -out data/keys/public.pem; \
+	fi;
+	@if [ -f ${SSL_CERT_PATH}/server.key ]; then echo "SSL key existing already. Skipping creating self signed cert."; else \
+		echo "Creating self signed SSL certificate."; \
+		mkdir -p ${SSL_CERT_PATH}; \
+		openssl req  -nodes -new -x509  -keyout ${SSL_CERT_PATH}/server.key -out ${SSL_CERT_PATH}/server.cert -subj "/C=UK/ST=NRW/L=London/O=My Inc/OU=DevOps/CN=www.streammyiot.com/emailAddress=donotreply@www.streammyiot.com"; \
 	fi;
 	@touch $@
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       - websocket-server
       - dashboard
     volumes:
+      - ./data/keys/ssl:/etc/ssl
       - ./oisp-frontend/public-interface:/app
   websocket-server:
     build:


### PR DESCRIPTION
Makefile puts keys into data/keys/ssl
docker-compose.yml lets nginx mount data/keys/ssl to /etc/ssl
Attention: A parallel PR is needed in oisp-frontend to add this path to default.conf in nginx module