### PR TITLE
Remove volume mount from websocket-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,6 @@ services:
       - postgres
       - kafka
     volumes:
-      - ./oisp-websocket-server:/app
       - ./data/keys:/app/keys
     working_dir: /app
     environment:


### PR DESCRIPTION
The volume is no longer required as the source is moved into the container.