### PR TITLE
Created a new container for debugging [DISCUSSION]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,14 @@ SSL_CERT_PATH:=data/keys/ssl
 
 COMPOSE_PROJECT_NAME?="oisp"
 DOCKER_REGISTRY=""
-CONTAINERS?=""
-DOCKER_COMPOSE_ARGS?=""
+CONTAINERS?=$(shell docker-compose --log-level ERROR config --services)
+DOCKER_COMPOSE_ARGS?=
 PULL_IMAGES?=false
+DEBUG?=false
+
+ifeq  ($(DEBUG),true)
+CONTAINERS:=$(CONTAINERS) debugger
+endif
 
 .init:
 	@$(call msg,"Initializing ...");
@@ -97,34 +102,37 @@ endif
 ##     You can specify a version using the $DOCKER_TAG argument.
 ##     $CONTAINERS arg (as whitespace seperated list) specifies which containers should be built,
 ##     if it is left blank, all containers will be built.
+##     If $DEBUG is set to true, debugger will be added to CONTAINERS
 ##     This command also accepts the argument $DOCKER_COMPOSE_ARGS, which is passed directly to compose.
 ##
 build: .init
 	@$(call msg,"Building OISP containers");
-	@./docker.sh build $(DOCKER_COMPOSE_ARGS) $(CONTAINERS)
+	@./docker.sh -f docker-compose.yml -f docker-debugger/docker-compose-debugger.yml build $(DOCKER_COMPOSE_ARGS) $(CONTAINERS);
 
 ## pull: Pull OISP containers from dockerhub. Requires docker login.
 ##     You can specify a version using the $DOCKER_TAG argument.
 ##     $CONTAINERS arg (as whitespace seperated list) specifies which containers should be pulled,
 ##     if it is left blank, all containers will be pulled.
+##     If $DEBUG is set to true, debugger will be added to CONTAINERS
 ##     This command also accepts the argument $DOCKER_COMPOSE_ARGS, which is passed directly to compose.
 ##
 pull: .init
 	@$(call msg, "Pulling OISP containers");
-	@./docker.sh pull $(DOCKER_COMPOSE_ARGS) $(CONTAINERS)
+	@./docker.sh -f docker-compose.yml -f docker-debugger/docker-compose-debugger.yml pull $(DOCKER_COMPOSE_ARGS) $(CONTAINERS);
 
 ## start: Start OISP.
 ##     You can specify a version using the $DOCKER_TAG argument.
 ##     If the images are not present, this will try to pull or build them, depending on the
 ##     value of $PULL_IMAGES (true/false; defaults to false)
-##     $CONTAINERS arg (as whitespace seperated list) specifies which containers should be started,
-##     if it is left blank, all containers will be started.
+##     If DEBUG is set to true, debugger will be added to containers
+##     CONTAINERS arg (as whitespace seperated list) specifies which containers should be started,
+##     if it is left blank, all containers except `debugger` will be started.
 ##     This command also accepts the argument $DOCKER_COMPOSE_ARGS, which is passed directly to compose.
 ##
 start:
 	@$(call msg,"Starting OISP");
 	@if [ "${PULL_IMAGES}" = "true" ]; then make pull; fi;
-	@./docker.sh up -d $(DOCKER_COMPOSE_ARGS) $(CONTAINERS)
+	@./docker.sh -f docker-compose.yml -f docker-debugger/docker-compose-debugger.yml up -d $(DOCKER_COMPOSE_ARGS) $(CONTAINERS)
 
 start-test: export TEST := "1"
 start-test:
@@ -134,12 +142,12 @@ start-test:
 
 ## stop: Stop running OISP containers.
 ##     $CONTAINERS arg (as whitespace seperated list) specifies which containers should be stopped,
-##     if it is left blank, all containers will be stopped.
+##     if it is left blank, all containers except `debugger` will be stopped.
 ##     This command also accepts the argument $DOCKER_COMPOSE_ARGS, which is passed directly to compose.
 ##
 stop:
 	@$(call msg,"Stopping OISP containers");
-	@./docker.sh stop $(DOCKER_COMPOSE_ARGS) $(CONTAINERS)
+	@./docker.sh -f docker-compose.yml -f docker-debugger/docker-compose-debugger.yml stop $(DOCKER_COMPOSE_ARGS) $(CONTAINERS)
 
 ## update: Update all subrepositories to latest origin/develop
 ##     For competabilty, this will also backup and remove setup-environment.sh

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ distclean: clean
 ##
 push-images:
 	@$(call msg,"Pushing docker images to registry");
-	@./docker.sh push $(CONTAINERS)
+	@./docker.sh -f docker-compose.yml -f docker-debugger/docker-compose-debugger.yml push $(CONTAINERS)
 
 ## help: Show this help message
 ##

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,10 +172,3 @@ services:
     environment:
       - VCAP_SERVICES=${VCAP_SERVICES}
       - VCAP_APPLICATION=${VCAP_APPLICATION}
-  debugger:
-    image: oisp/debugger:${DOCKER_TAG}
-    build:
-      context: ./docker-debugger
-      labels:
-        - oisp=true
-        - oisp.git_commit=${GIT_COMMIT_PLATFORM_LAUNCHER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,3 +172,10 @@ services:
     environment:
       - VCAP_SERVICES=${VCAP_SERVICES}
       - VCAP_APPLICATION=${VCAP_APPLICATION}
+  debugger:
+    image: oisp/debugger:${DOCKER_TAG}
+    build:
+      context: ./docker-debugger
+      labels:
+        - oisp=true
+        - oisp.git_commit=${GIT_COMMIT_PLATFORM_LAUNCHER}

--- a/docker-debugger/Dockerfile
+++ b/docker-debugger/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:xenial
+
+RUN apt-get update
+RUN apt-get -y install nano make git kafkacat python python-pip python3-pip python3-dev python3-setuptools python-setuptools build-essential nodejs dnsutils virtualenv snapd npm wget apt-transport-https curl
+
+# install kubectl
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+RUN touch /etc/apt/sources.list.d/kubernetes.list
+RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
+RUN apt-get update
+RUN apt-get install -y kubectl
+
+RUN alias node=nodejs
+
+ENV OISP_REMOTE https://github.com/Open-IoT-Service-Platform/platform-launcher.git
+
+CMD ["tail", "-f", "/dev/null"]

--- a/docker-debugger/Dockerfile
+++ b/docker-debugger/Dockerfile
@@ -9,8 +9,15 @@ RUN echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/ap
 RUN apt-get update
 RUN apt-get install -y kubectl
 
-RUN alias node=nodejs
+RUN npm install --global n
+RUN n 6
+
+RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 ENV OISP_REMOTE https://github.com/Open-IoT-Service-Platform/platform-launcher.git
+
+RUN mkdir /home/platform-launcher
+
+WORKDIR /home/platform-launcher
 
 CMD ["tail", "-f", "/dev/null"]

--- a/docker-debugger/Dockerfile
+++ b/docker-debugger/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:xenial
 
-RUN apt-get update
-RUN apt-get -y install nano make git kafkacat python python-pip python3-pip python3-dev python3-setuptools python-setuptools build-essential nodejs dnsutils virtualenv snapd npm wget apt-transport-https curl
+RUN apt-get update && apt-get -y install nano make git kafkacat python python-pip python3-pip python3-dev python3-setuptools python-setuptools build-essential nodejs dnsutils virtualenv snapd npm wget apt-transport-https curl
 
 # install kubectl
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -

--- a/docker-debugger/README.md
+++ b/docker-debugger/README.md
@@ -1,12 +1,16 @@
-Debug Container
+#Debug Container
 ===============
 
 This container has the tools that are often required to debug various parts of OISP, like kafkacat, node & npm, python & pip etc.
 
 Since this is not supposed to be deployed in production, lightness of this container is not a concern, so it is meant to be a all in one solution.
 
-Advantages over debugging via host machine
-------------------------------------------
+## Build & run
+
+Run the make commands from project root directory, and set DEBUG=true or add debugger to CONTAINERS.
+
+## Advantages over debugging via host machine
+
 
 1. Not all host machines necessarily have the tools installed.
 2. This can be used to access endpoints not exposed publicly within docker/k8s networks.

--- a/docker-debugger/README.md
+++ b/docker-debugger/README.md
@@ -1,0 +1,12 @@
+Debug Container
+===============
+
+This container has the tools that are often required to debug various parts of OISP, like kafkacat, node & npm, python & pip etc.
+
+Since this is not supposed to be deployed in production, lightness of this container is not a concern, so it is meant to be a all in one solution.
+
+Advantages over debugging via host machine
+------------------------------------------
+
+1. Not all host machines necessarily have the tools installed.
+2. This can be used to access endpoints not exposed publicly within docker/k8s networks.

--- a/docker-debugger/docker-compose-debugger.yml
+++ b/docker-debugger/docker-compose-debugger.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  debugger:
+    image: oisp/debugger:${DOCKER_TAG}
+    build:
+      context: docker-debugger
+      labels:
+        - oisp=true
+        - oisp.git_commit=${GIT_COMMIT_PLATFORM_LAUNCHER}


### PR DESCRIPTION
I have been using this container a lot myself for debugging, and I am planning to base the Kubernetes tests on a container, and I thought it might be useful to others too. We could also add an option to run the e2e tests in a container inside the OISP and/or a different docker network. 

Do you think it is a good idea to include it by default in docker-compose? It is not supposed to be deployed in production, but docker-compose is mainly our development platform anyway.