### PR TITLE
Add option DISABLE_RATE_LIMITS to Makefile for frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ DOCKER_COMPOSE_ARGS?=
 PULL_IMAGES?=false
 DEBUG?=false
 
+# Variable to remove rate limits for endpoints in frontend
+DISABLE_RATE_LIMITS?=false
+RATE_LIMIT = ''
+ifeq ($(DISABLE_RATE_LIMITS),true)
+RATE_LIMIT = '--disable-rate-limits'
+endif
+export RATE_LIMIT
+
 ifeq  ($(DEBUG),true)
 CONTAINERS:=$(CONTAINERS) debugger
 endif

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
       - websocket-server
       - backend
       - kafka
-    command: ./wait-for-it.sh postgres:5432 -t 300 -- ./wait-for-it.sh redis:6379 -t 300  -- ./wait-for-it.sh kafka:9092 -t 300 -- ./scripts/wait-for-heartbeat.sh backend websocket-server -- ./scripts/docker-start.sh
+    command: ./wait-for-it.sh postgres:5432 -t 300 -- ./wait-for-it.sh redis:6379 -t 300  -- ./wait-for-it.sh kafka:9092 -t 300 -- ./scripts/wait-for-heartbeat.sh backend websocket-server -- ./scripts/docker-start.sh ${RATE_LIMIT}
     volumes:
       - ./data/keys:/app/keys
     environment:


### PR DESCRIPTION
Setting DISABLE_RATE_LIMITS=true will now disable the rate limits security check at frontend. Should be committed with [#75](https://github.com/Open-IoT-Service-Platform/oisp-frontend/pull/75).