### PR TITLE
E2E-tests/data-sending-tests: Update user creation for k8s

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -69,6 +69,7 @@ else
 
 	@$(call msg,"Adding a user for testing ...");
 	@kubectl exec -i $(DASHBOARD_POD) -c dashboard --  node /app/admin addUser $(USERNAME) $(PASSWORD) $(ROLE) > /dev/null
+	@kubectl exec -i $(DASHBOARD_POD) -c dashboard --  node /app/admin addUser $(USERNAME2) $(PASSWORD2) $(ROLE2) > /dev/null
 
 endif
 	@$(call msg,"Starting the e2e testing ...");


### PR DESCRIPTION
e6d5582d9 introduces a second user, which must be created when testing with k8s as well

Signed-off-by: Ali Rasim Kocal <arkocal@gmail.com>