### PR TITLE
tests/Makefile: Send kafacat producer output to >/dev/null. It create…

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -52,8 +52,8 @@ test: npm-install
 	@$(call msg,"Waiting for frontend and test Kafka readiness");
 # fill in separator to avoid accidentially dashboard being most recent heartbeat.
 # Then look always for latest heartbeat
-	@until echo new-test | kafkacat -P -b $(KAFKA_BROKER) -t heartbeat; do echo "Kafka not ready. Waiting ..."; sleep 1; done
-	@ (for i in {1..4}; do echo new-test ; done) | kafkacat -P -b $(KAFKA_BROKER) -t heartbeat;
+	@until echo new-test | kafkacat -P -b $(KAFKA_BROKER) -t heartbeat >/dev/null; do echo "Kafka not ready. Waiting ..."; sleep 1; done
+	@ (for i in {1..4}; do echo new-test ; done) | kafkacat -P -b $(KAFKA_BROKER) -t heartbeat >/dev/null;
 	@. ../setup-environment.sh && until kafkacat -C -b $(KAFKA_BROKER) -t heartbeat -e -o -4 2> /dev/null | grep -m 1 "dashboard"; do sleep 1 ; done
 
 ifeq ($(TESTING_PLATFORM), docker)


### PR DESCRIPTION
…s a huge amount of output when Kakfa service is not ready