### PR TITLE
Revert "Postgres: Do not copy *.sql files"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ start: .init
 	@if [ "${PULL_IMAGES}" = "true" ]; then make pull; fi;
 	@./docker.sh -f docker-compose.yml -f docker-debugger/docker-compose-debugger.yml up -d $(DOCKER_COMPOSE_ARGS) $(CONTAINERS)
 
-start-test: export TEST := 1
+start-test: export TEST := "1"
 start-test:
 	@$(call msg,"Starting OISP (test mode: $(TESTING_PLATFORM) )");
 	@make -C tests email-account $(shell pwd)/tests/.env

--- a/docker-postgres/Dockerfile
+++ b/docker-postgres/Dockerfile
@@ -1,3 +1,5 @@
 FROM postgres:9.4-alpine
 
+COPY ./oisp-frontend/public-interface/deploy/postgres/base/*.sql /docker-entrypoint-initdb.d/
 COPY ./oisp-frontend/public-interface/scripts/database/create_test_database.sh /docker-entrypoint-initdb.d/
+


### PR DESCRIPTION
This reverts commit 749c529deb1f3e6a487d7c0555d46a739ce863f5.

Until the sequelize table creation problem at frontend is solved, *.sql files must be copied back.

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>