### PR TITLE
Fix circleci nightly build bug, frontend no longer depends on opentsd…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
       - websocket-server
       - backend
       - kafka
-    command: ./wait-for-it.sh opentsdb:4242 -t 300 -- ./wait-for-it.sh grafana:3000 -t 300 -- ./wait-for-it.sh postgres:5432 -t 300 -- ./wait-for-it.sh redis:6379 -t 300  -- ./wait-for-it.sh kafka:9092 -t 300 -- ./scripts/wait-for-heartbeat.sh backend websocket-server -- ./scripts/docker-start.sh ${RATE_LIMIT}
+    command: ./wait-for-it.sh postgres:5432 -t 300 -- ./wait-for-it.sh redis:6379 -t 300  -- ./wait-for-it.sh kafka:9092 -t 300 -- ./scripts/wait-for-heartbeat.sh backend websocket-server -- ./scripts/docker-start.sh ${RATE_LIMIT}
     volumes:
       - ./data/keys:/app/keys
     environment:
@@ -339,7 +339,7 @@ services:
       context: ./docker-grafana
       labels:
         - oisp=true
-        - ois.git_commit=${GIT_COMMIT_OPENTSDB}
+        - oisp.git_commit=${GIT_COMMIT_PLATFORM_LAUNCHER}
     ports:
       - 3000:3000
     environment:

--- a/docker-grafana/Dockerfile
+++ b/docker-grafana/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GRAFANA_VERSION="latest"
+ARG GRAFANA_VERSION="6.2.2"
 
 FROM grafana/grafana:${GRAFANA_VERSION}
 


### PR DESCRIPTION
…b or grafana:

docker-grafana/Dockerfile: specified grafana version to prevent circleci pushing to wrong location
docker-compose.yml: removed frontend wait-for-heartbeats for grafana and opentsdb

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>