### PR TITLE
beam-rule-engine: Update submodule URL to use HTTPS instead of GIT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/Open-IoT-Service-Platform/oisp-mqtt-gw.git
 [submodule "oisp-beam-rule-engine"]
 	path = oisp-beam-rule-engine
-	url = git@github.com:Open-IoT-Service-Platform/oisp-beam-rule-engine.git
+	url = https://github.com/Open-IoT-Service-Platform/oisp-beam-rule-engine.git


### PR DESCRIPTION
Signed-off-by: Ali Rasim Kocal <arkocal@gmail.com>