### PR TITLE
mqtt-subtests: give the backend 1s more time to synchronize

### DIFF
--- a/tests/subtests/mqtt-data-sending-tests.js
+++ b/tests/subtests/mqtt-data-sending-tests.js
@@ -461,7 +461,7 @@ var test = function(userToken, accountId, deviceId, deviceToken, cbManager, mqtt
 
         },
         "waitForBackendSynchronization": function(done) {
-            setTimeout(done, 2000);
+            setTimeout(done, 3000);
 
         },
 


### PR DESCRIPTION
Signed-off-by: Marcel Wagner <wagmarcel@web.de>