### PR TITLE
docs: Minor config change to enable autobuild on readthedocs.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ author = 'oisp'
 # The full version, including alpha/beta/rc tags
 release = 'v1.1-beta1'
 
+master_doc = 'index'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
This was tested on my fork with automated build on https://oisp-wip.readthedocs.org 