### PR TITLE
Change in Ingress to allow automated cert-management

### DIFF
--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -79,3 +79,14 @@ Interacting with OISP
 You can interact with OISP using the `REST API <https://streammyiot.com/ui/public/api.html>`_, or with our SDKs for `javascript <https://github.com/Open-IoT-Service-Platform/oisp-sdk-js>`_ and `python <https://github.com/Open-IoT-Service-Platform/oisp-sdk-python>`_.
 
 .. warning:: Using the SDKs is the recommended way of interacting with the platform, however, they might not be always up to date with the latest features. Please feel welcome to open issues for any incompatibility problems between the API and the SDKs.
+
+
+Cert-Manager
+------------
+
+OISP is prepared to be used with cert-manager to retrieve and update certificates from letsencrypt.
+To configure the cert-manager:
+
+1. Install cert-manager as described `here <https://docs.cert-manager.io/en/release-0.11/getting-started/install/kubernetes.html>`_ .
+2. Install issuer `kubectl apply -f kubernetes/cert-manager/clusterissuer-prod.yaml`. Note that it is managing certificcates cluster wide and thus does not have a namespace.
+3. Adapt email address in  `kubernetes/certificate_web_prod.yaml`. Install the certificate in namespace oisp: `kubectl apply -f kubernetes/certificate_web_prod.yaml -n oisp`

--- a/kubernetes/cert-manager/certificate_web_prod.yaml
+++ b/kubernetes/cert-manager/certificate_web_prod.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: dashboard-web-prod-tls
+  namespace: oisp
+spec:
+  secretName: dashboard-web-prod-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  dnsNames:
+  - latest.streammyiot.com
+  - ws.latest.streammyiot.com
+  issuerRef:
+    name: letsencrypt-prod
+    # We can reference ClusterIssuers by changing the kind here.
+    # The default value is Issuer (i.e. a locally namespaced Issuer)
+    kind: ClusterIssuer

--- a/kubernetes/cert-manager/clusterissuer-prod.yaml
+++ b/kubernetes/cert-manager/clusterissuer-prod.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  namespace: cert-manager
+spec:
+  acme:
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: info@streammyiot.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource used to store the account's private key.
+      name: ca-account-key-prod
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          name: dashboard-web-http

--- a/kubernetes/templates/frontend.yaml
+++ b/kubernetes/templates/frontend.yaml
@@ -174,16 +174,3 @@ spec:
           - key: jwt.privatekey
             path: private.pem
           secretName: oisp-secrets
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: dashboard-web
-spec:
-  rules:
-  - host: k8s.streammyiot.com
-    http:
-      paths:
-      - backend:
-          serviceName: dashboard
-          servicePort: 4001

--- a/kubernetes/templates/ingress.yaml
+++ b/kubernetes/templates/ingress.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dashboard-web-http
+spec:
+  rules:
+  - host: {{ .Values.hosts.frontend }}
+    http:
+      paths:
+      - backend:
+          serviceName: dashboard
+          servicePort: 4001
+  - host: {{ .Values.hosts.websocketserver }}
+    http:
+      paths:
+      - backend:
+          serviceName: websocket-server
+          servicePort: 5000
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dashboard-web
+spec:
+  backend:
+    serviceName: dashboard
+    servicePort: 4001 
+  tls:
+  - hosts:
+    - latest.streammyiot.com
+    - ws.latest.streammyiot.com
+    secretName: dashboard-web-prod-tls 
+  rules:
+  - host: {{ .Values.hosts.frontend }}
+    http:
+      paths:
+      - path: / 
+        backend:
+          serviceName: dashboard
+          servicePort: 4001
+  - host: {{ .Values.hosts.websocketserver }}
+    http:
+      paths:
+      - path: / 
+        backend:
+          serviceName: websocket-server
+          servicePort: 5000
+

--- a/kubernetes/templates/websocket-server.yaml
+++ b/kubernetes/templates/websocket-server.yaml
@@ -94,16 +94,3 @@ spec:
           - key: jwt.privatekey
             path: private.pem
           secretName: oisp-secrets
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: dashboard-ws
-spec:
-  rules:
-  - host: {{ .Values.hosts.websocketserver }}
-    http:
-      paths:
-      - backend:
-          serviceName: websocket-server
-          servicePort: 5000

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -36,9 +36,9 @@ mqtt:
 
 # Hosts used for Ingress configuration
 hosts:
-    frontend: k8s.streammyiot.com
-    websocketserver: ws.streammyiot.com
-    mqttserver: mqtt.streammyiot.com
+    frontend: latest.streammyiot.com
+    websocketserver: ws.latest.streammyiot.com
+    mqttserver: mqtt.latest.streammyiot.com
 
 systemuser:
   username: gateway@intel.com


### PR DESCRIPTION
* frontend and websoket-server have now same http and https ingres to allow to create joint letsencrypt certificates
* provided templates for automated cert-management

Signed-off-by: Marcel Wagner <wagmarcel@web.de>