### PR TITLE
Fixed wrong rule configuration in e2e test:

### DIFF
--- a/tests/lib/helpers/rules.js
+++ b/tests/lib/helpers/rules.js
@@ -227,7 +227,7 @@ function createTbRule(ruleConfig, userToken, accountId, deviceId, cb) {
             priority: "Medium",
             type: "Regular",
             status: "Active",
-            resetType: "Manual",
+            resetType: "Automatic",
             synchronizationStatus: "NotSync",
 
             actions: ruleConfig.actions,


### PR DESCRIPTION
Rule test assumed Automatic resetType rule but configured Manual resetType. Until now there was no difference in Alert behaviour but in future the Alert module will react differently to Manual resetType.

Signed-off-by: Marcel Wagner <wagmarcel@web.de>