### PR TITLE
Fix: Docker-compose file has been updated to use K8s 1.16 which does …

### DIFF
--- a/util/restart-cluster.sh
+++ b/util/restart-cluster.sh
@@ -2,7 +2,7 @@ printf "\033[1mStarting k3s\n"
 printf -- "------------\033[0m\n"
 rm -rf ~/k3s
 mkdir ~/k3s
-curl https://raw.githubusercontent.com/rancher/k3s/master/docker-compose.yml > ~/k3s/docker-compose.yml
+curl https://raw.githubusercontent.com/rancher/k3s/36dc38f361ebb9d57184493e31f45efb097e47fe/docker-compose.yml > ~/k3s/docker-compose.yml
 # Compose down is necessary for subsequent runs to succeed
 cd ~/k3s && sudo docker-compose down -v && sudo docker-compose up -d
 printf "Waiting for k3s to create kubeconfig file\n"


### PR DESCRIPTION
…not work with our tiller setup. Using explicit hash for now.

Signed-off-by: Marcel Wagner <wagmarcel@web.de>