### PR TITLE
Rename dashboard to frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ NAME?=$(NAMESPACE)
 DEPLOYMENT?=debugger
 DEBUGGER_POD:=$(shell kubectl -n $(NAMESPACE) get pods -o custom-columns=:metadata.name | grep debugger | head -n 1)
 SELECTED_POD:=$(shell kubectl -n $(NAMESPACE) get pods -o custom-columns=:metadata.name | grep $(DEPLOYMENT) | head -n 1)
-DASHBOARD_POD:=$(shell kubectl -n $(NAMESPACE) get pods -o custom-columns=:metadata.name | grep dashboard | head -n 1)
+FRONTEND_POD:=$(shell kubectl -n $(NAMESPACE) get pods -o custom-columns=:metadata.name | grep frontend | head -n 1)
 
 .init:
 	@$(call msg,"Initializing ...");
@@ -167,15 +167,15 @@ undeploy-oisp:
 ## reset-db: Reset database via admin tool in frontend
 ##
 reset-db:
-	kubectl -n $(NAMESPACE) exec $(DASHBOARD_POD) --container dashboard -- node admin resetDB
+	kubectl -n $(NAMESPACE) exec $(FRONTEND_POD) --container frontend -- node admin resetDB
 
 ## add-test-user: Add a test user via admin tool in frontend
 ##
 add-test-user:
-	for i in $(shell seq 1 1); do kubectl -n $(NAMESPACE) exec $(DASHBOARD_POD) -c dashboard -- node admin addUser user$${i}@example.com password admin; done;
+	for i in $(shell seq 1 1); do kubectl -n $(NAMESPACE) exec $(FRONTEND_POD) -c frontend -- node admin addUser user$${i}@example.com password admin; done;
 
 ## wait-until-ready: Wait until the platform is up and running
-##     As of now, this is assumed if all dashboard and backend containers
+##     As of now, this is assumed if all frontend and backend containers
 ##     are ready.
 ##
 wait-until-ready:
@@ -187,7 +187,7 @@ wait-until-ready:
         jsonpath="{.items[*].status.containerStatuses[*].ready}" | grep false >> /dev/null; \
 		do printf "."; sleep 5; done;
 	@printf "\nWaiting for frontend ";
-	@while kubectl -n $(NAMESPACE) get pods -l=app=dashboard -o \
+	@while kubectl -n $(NAMESPACE) get pods -l=app=frontend -o \
         jsonpath="{.items[*].status.containerStatuses[*].ready}" | grep false >> /dev/null; \
 		do printf "."; sleep 5; done;
 	@printf "\nWaiting for mqtt server";

--- a/kubernetes/templates/configmaps/oisp-config.yaml
+++ b/kubernetes/templates/configmaps/oisp-config.yaml
@@ -2,14 +2,17 @@ apiVersion: v1
 data:
   postgres.database: oisp
   postgres.username: oisp
-
+  # This dictionary contains frontendSecurityConfig and dashboardSecurityConfig
+  # for backwards competability. The later can be removed with the comment
+  # after the frontend is updated
   frontend: |
     {
     "postgresConfig": "@@OISP_POSTGRES_CONFIG",
     "redisConfig": "@@OISP_REDIS_CONFIG",
     "kafkaConfig": "@@OISP_KAFKA_CONFIG",
     "smtpConfig": "@@OISP_SMTP_CONFIG",
-    "dashboardSecurityConfig": "@@OISP_DASHBOARDSECURITY_CONFIG",
+    "frontendSecurityConfig": "@@OISP_FRONTENDSECURITY_CONFIG",
+    "dashboardSecurityConfig": "@@OISP_FRONTENDSECURITY_CONFIG",
     "backendHostConfig": "@@OISP_BACKENDHOST_CONFIG",
     "websocketUserConfig": "@@OISP_WEBSOCKETUSER_CONFIG",
     "mailConfig": "@@OISP_MAIL_CONFIG",
@@ -109,7 +112,7 @@ data:
     "username": "{{ .Values.smtp.username }}",
     "password": "{{ .Values.smtp.password }}"
     }
-  dashboard-security: |
+  frontend-security: |
     {
     "captcha_test_code": "s09ef48213s8fe8fw8rwer5489wr8wd5",
     "interaction_token_permision_key": "password",
@@ -137,7 +140,7 @@ data:
     "username": "{{ .Values.ruleEngine.username }}",
     "gearpumpUsername": "{{ .Values.ruleEngine.gearpump.username }}",
     "gearpumpPassword": "{{ .Values.ruleEngine.gearpump.password }}",
-    "frontendUri": "dashboard:4001",
+    "frontendUri": "frontend:4001",
     "hbaseConfig": "@@OISP_HBASE_CONFIG",
     "kafkaConfig": "@@OISP_KAFKA_CONFIG",
     "zookeeperConfig": "@@OISP_ZOOKEEPER_CONFIG"
@@ -179,7 +182,7 @@ data:
     "mqttBrokerPort": "8883",
     "mqttBrokerUsername": "{{ .Values.mqtt.broker.username }}",
     "mqttBrokerPassword": "{{ .Values.mqtt.broker.password }}",
-    "frontendUri": "dashboard",
+    "frontendUri": "frontend",
     "frontendPort": "4001",
     "frontendSystemUser": "{{ .Values.systemuser.username }}",
     "frontendSystemPassword": "{{ .Values.systemuser.password }}",

--- a/kubernetes/templates/frontend.yaml
+++ b/kubernetes/templates/frontend.yaml
@@ -3,30 +3,30 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard
-  name: dashboard
+    app: frontend
+  name: frontend
 spec:
   ports:
   - port: 4001
-    name: "dashboard"
+    name: "frontend"
   - port: 4002
     name: "4002"
   - port: 4003
     name: "4003"
   selector:
-    app: dashboard
+    app: frontend
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard
-  name: dashboard
+    app: frontend
+  name: frontend
 spec:
   replicas: {{ .Values.numberReplicas.frontend }}
   selector:
     matchLabels:
-      app: dashboard
+      app: frontend
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -35,10 +35,10 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard
+        app: frontend
     spec:
       containers:
-      - name: dashboard
+      - name: frontend
         image: oisp/frontend:{{ .Values.tag }}
         ports:
         - containerPort: 4001
@@ -88,11 +88,11 @@ spec:
             configMapKeyRef:
               name: oisp-config
               key: smtp
-        - name: OISP_DASHBOARDSECURITY_CONFIG
+        - name: OISP_FRONTENDSECURITY_CONFIG
           valueFrom:
             configMapKeyRef:
               name: oisp-config
-              key: dashboard-security
+              key: frontend-security
         - name: OISP_GATEWAY_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/kubernetes/templates/grafana.yaml
+++ b/kubernetes/templates/grafana.yaml
@@ -34,7 +34,7 @@ spec:
         - containerPort: 3000
         env:
         - name: GF_SERVER_DOMAIN
-          value: dashboard
+          value: frontend
         - name: GF_SERVER_ROOT_URL
           value: "%(protocol)s://%(domain)s:%(http_port)s/ui/grafana"
         - name: GF_SERVER_HTTP_PORT
@@ -44,7 +44,7 @@ spec:
         - name: GF_SECURITY_ADMIN_PASSWORD
           value: {{ .Values.grafana.password }}
         - name: DATASOURCE_URL
-          value: http://dashboard:4003
+          value: http://frontend:4003
         resources:
           {{ if .Values.less_resources }}
           limits:

--- a/kubernetes/templates/jobs/db_setup.yaml
+++ b/kubernetes/templates/jobs/db_setup.yaml
@@ -40,11 +40,11 @@ spec:
             configMapKeyRef:
               name: oisp-config
               key: smtp
-        - name: OISP_DASHBOARDSECURITY_CONFIG
+        - name: OISP_FRONTENDSECURITY_CONFIG
           valueFrom:
             configMapKeyRef:
               name: oisp-config
-              key: dashboard-security
+              key: frontend-security
         - name: OISP_GATEWAY_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/kubernetes/templates/jobs/db_update.yaml
+++ b/kubernetes/templates/jobs/db_update.yaml
@@ -40,11 +40,11 @@ spec:
             configMapKeyRef:
               name: oisp-config
               key: smtp
-        - name: OISP_DASHBOARDSECURITY_CONFIG
+        - name: OISP_FRONTENDSECURITY_CONFIG
           valueFrom:
             configMapKeyRef:
               name: oisp-config
-              key: dashboard-security
+              key: frontend-security
         - name: OISP_GATEWAY_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,7 +31,7 @@ PASSWORD2 = "OispTesting2"
 ROLE2 = "admin"
 
 NAMESPACE?=oisp
-DASHBOARD_POD:=$(shell kubectl -n $(NAMESPACE) get pods -o custom-columns=:metadata.name | grep dashboard | head -n 1)
+FRONTEND_POD:=$(shell kubectl -n $(NAMESPACE) get pods -o custom-columns=:metadata.name | grep frontend | head -n 1)
 
 npm-install:
 	@$(call msg,"Installing npm packages ...");
@@ -41,10 +41,10 @@ test: npm-install
 	@export OISP_GRAFANA_PASSWORD=$$(kubectl -n $(NAMESPACE) get -o yaml configmaps oisp-config | shyaml get-value data.grafana | jq -r .adminPassword) && \
 	cat test-config-template.json | envsubst > test-config.json
 	@$(call msg,"Resetting database ...");
-	@kubectl exec -i $(DASHBOARD_POD) -c dashboard --  node /app/admin resetDB
+	@kubectl exec -i $(FRONTEND_POD) -c frontend --  node /app/admin resetDB
 	@$(call msg,"Adding a user for testing ...");
-	@kubectl exec -i $(DASHBOARD_POD) -c dashboard --  node /app/admin addUser $(USERNAME) $(PASSWORD) $(ROLE) > /dev/null
-	@kubectl exec -i $(DASHBOARD_POD) -c dashboard --  node /app/admin addUser $(USERNAME2) $(PASSWORD2) $(ROLE2) > /dev/null
+	@kubectl exec -i $(FRONTEND_POD) -c frontend --  node /app/admin addUser $(USERNAME) $(PASSWORD) $(ROLE) > /dev/null
+	@kubectl exec -i $(FRONTEND_POD) -c frontend --  node /app/admin addUser $(USERNAME2) $(PASSWORD2) $(ROLE2) > /dev/null
 
 ifndef TEST_PREP_ONLY
 	@$(call msg,"Starting the e2e testing ...");

--- a/tests/test-config-template.json
+++ b/tests/test-config-template.json
@@ -7,7 +7,7 @@
 	"default_connector": "rest+ws",
 	"connector": {
 		"rest": {
-			"host": "dashboard",
+			"host": "frontend",
 			"port": 4001,
 			"protocol": "http",
 			"strictSSL": false,
@@ -38,7 +38,7 @@
 		}
 	},
 	"grafana": {
-		"host": "dashboard",
+		"host": "frontend",
 		"port": 4002,
 		"protocol": "http",
 		"subPath": "/ui/grafana",


### PR DESCRIPTION
This was done in order to remove the ambiguity, as both were used interchangably, which is problematic for the plans of seperating them into two microservices.

Signed-off-by: Ali Rasim Kocal <arkocal@posteo.net>