### PR TITLE
Low latency patch for OpenTSDB

### DIFF
--- a/docker/opentsdb/scripts/tsdb-startup.sh
+++ b/docker/opentsdb/scripts/tsdb-startup.sh
@@ -51,6 +51,7 @@ replace_config "tsd.network.port" ${PORT} ""
 replace_config "tsd.core.auto_create_metrics" "true" "#"
 add_config "tsd.http.request.enable_chunked" "true"
 add_config "tsd.http.request.cors_domains" "*"
+add_config "tsd.storage.flush_interval" "100"
 
 /opt/opentsdb/src/create_table.sh
 echo "Result $?"


### PR DESCRIPTION
The flush intervall has been reduced to 100ms.

Signed-off-by: Marcel Wagner <wagmarcel@web.de>