### PR TITLE
Helm and setup dependencies changed to speedup helm deployments

### DIFF
--- a/kubernetes/templates/frontend.yaml
+++ b/kubernetes/templates/frontend.yaml
@@ -56,7 +56,7 @@ spec:
         - "300"
         - --
         - ./wait-for-it.sh
-        - hbase-master:9090
+        - oisp-keycloak-http:4080
         - -t
         - "300"
         - --

--- a/kubernetes/templates/hbase-master.yaml
+++ b/kubernetes/templates/hbase-master.yaml
@@ -58,7 +58,11 @@ spec:
           {{ end }}
         env:
         - name: REGIONSERVERS
+          {{ if .Values.less_resources  }}
+          value: {{ .Values.hbaseScale.regionServersTest }}
+          {{ else }}
           value: {{ .Values.hbaseScale.regionServers }}
+          {{ end }}
         - name: ZOOKEEPER
           value: zookeeper
         - name: HDFS_NAMENODE

--- a/kubernetes/templates/hbase-region.yaml
+++ b/kubernetes/templates/hbase-region.yaml
@@ -20,7 +20,11 @@ metadata:
     app: hbase-region
 spec:
   serviceName: hbase-region
+  {{ if .Values.less_resources }}
+  replicas: 1
+  {{ else }}
   replicas: {{ .Values.hbaseScale.dataNodes }}
+  {{ end }}
   selector:
     matchLabels:
       app: hbase-region

--- a/kubernetes/templates/hdfs-datanode.yaml
+++ b/kubernetes/templates/hdfs-datanode.yaml
@@ -19,7 +19,11 @@ metadata:
   name: hdfs-datanode
 spec:
   serviceName: hdfs-datanode
+  {{ if .Values.less_resources }}
+  replicas: 1
+  {{ else }}
   replicas: {{ .Values.hbaseScale.dataNodes }}
+  {{ end }}
   selector:
     matchLabels:
       app: hdfs-datanode

--- a/kubernetes/templates/jobs/db_setup.yaml
+++ b/kubernetes/templates/jobs/db_setup.yaml
@@ -3,7 +3,6 @@ kind: Job
 metadata:
   name: dbsetup
   annotations:
-    "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
@@ -75,7 +74,7 @@ spec:
             configMapKeyRef:
               name: oisp-config
               key: keycloak
-        command: ["./wait-for-it.sh", "postgres:5432", "-t", "300", "--", "./wait-for-it.sh", "oisp-keycloak-http:4080", "-t", "300", "--", "node", "admin", "createDB"]
+        command: ["./wait-for-it.sh", "postgres:5432", "-t", "300", "--", "node", "admin", "createDB"]
       restartPolicy: Never
       imagePullSecrets:
         - name: dockercred

--- a/kubernetes/templates/jobs/db_update.yaml
+++ b/kubernetes/templates/jobs/db_update.yaml
@@ -3,7 +3,6 @@ kind: Job
 metadata:
   name: dbupdate
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "20"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
@@ -75,7 +74,7 @@ spec:
             configMapKeyRef:
               name: oisp-config
               key: keycloak
-        command: ["node", "admin", "updateDB"]
+        command: ["./wait-for-it.sh", "postgres:5432", "-t", "300", "--", "./wait-for-it.sh", "frontend:4001", "-t", "300", "--", "node", "admin", "updateDB"]
       restartPolicy: Never
       imagePullSecrets:
         - name: dockercred

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -25,6 +25,7 @@ numberReplicas:
 hbaseScale:
   dataNodes: 3
   regionServers: "hbase-region-0.hbase-region hbase-region-1.hbase-region hbase-region-2.hbase-region"
+  regionServersTest: "hbase-region-0.hbase-region"
 
 minio:
   accesskey: minio

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,9 +38,6 @@ npm-install:
 test: npm-install
 	@export OISP_GRAFANA_PASSWORD=$$(kubectl -n $(NAMESPACE) get -o yaml configmaps oisp-config | shyaml get-value data.grafana | jq -r .adminPassword) && \
 	cat test-config-template.json | envsubst > test-config.json
-	@$(call msg,"Resetting database ...");
-	@kubectl -n $(NAMESPACE) exec -i $(FRONTEND_POD) -c frontend --  node /app/admin resetKeycloakUsers
-	@kubectl -n $(NAMESPACE) exec -i $(FRONTEND_POD) -c frontend --  node /app/admin resetDB
 	@$(call msg,"Adding a user for testing ...");
 	@kubectl -n $(NAMESPACE) exec -i $(FRONTEND_POD) -c frontend --  node /app/admin addUser $(USERNAME) $(PASSWORD) > /dev/null
 	@kubectl -n $(NAMESPACE) exec -i $(FRONTEND_POD) -c frontend --  node /app/admin addUser $(USERNAME2) $(PASSWORD2) > /dev/null

--- a/tests/oisp-tests.js
+++ b/tests/oisp-tests.js
@@ -405,7 +405,7 @@ describe("get authorization and manage user ...\n".bold, function() {
         assert.isNotEmpty(password, "no password2 provided");
 
         getNewUserTokens(done);
-    });
+    }).timeout(10000);
 
     it('Shall get token info', function (done) {
         helpers.auth.tokenInfo(userToken, function (err, response) {
@@ -1057,7 +1057,7 @@ describe("Sending observations and checking rules ...\n".bold, function() {
 
         sendObservationAndCheckRules(components.first);
 
-    }).timeout(5*60*1000)
+    }).timeout(60*1000)
 
     //---------------------------------------------------------------
 


### PR DESCRIPTION
* Changed dependencies of dbsetup/dbupdate, keycloak and frontend. These jobs/pods created the 10min waiting time when helm chart
was installed. Instea
* Removed db and keycloak reset since this does not bring any advantage for test but created race condition with rule-enging token
* Reduced number of hbase and minio containers to minimum
* Added wait for debugger container
* Increased timeouts for authentication

Signed-off-by: Marcel Wagner <wagmarcel@web.de>