### PR TITLE
Fix in Helm templates: Wrong letter for millicpu in hdfs-datanode and…

### DIFF
--- a/kubernetes/templates/hdfs-datanode.yaml
+++ b/kubernetes/templates/hdfs-datanode.yaml
@@ -46,7 +46,7 @@ spec:
             cpu: 1
           requests:
             memory: 500M
-            cpu: 500M
+            cpu: 500m
           {{ end }}
         env:
           - name: HDFS_USER

--- a/kubernetes/templates/hdfs-namenode.yaml
+++ b/kubernetes/templates/hdfs-namenode.yaml
@@ -57,7 +57,7 @@ spec:
             cpu: 500m
           requests:
             memory: 500M
-            cpu: 500M
+            cpu: 500m
           {{ end }}
         env:
           - name: HDFS_USER

--- a/tests/oisp-tests.js
+++ b/tests/oisp-tests.js
@@ -1250,8 +1250,10 @@ describe("Do data sending subtests ...".bold, function() {
        test.sendDataAsUser(done);
      }).timeout(10000);
      it(descriptions.waitForBackendSynchronization,function(done) {
-       test.waitForBackendSynchronization(BACKEND_DELAY, done);
-     }).timeout(BACKEND_TIMEOUT);
+       // Due to low profile of test environment and the fact that Kafka/Backend is processing all the 1000s of samples
+       // separately, we need to give the backend more time to settle
+       test.waitForBackendSynchronization(BACKEND_DELAY * 2, done);
+     }).timeout(BACKEND_TIMEOUT * 2);
      it(descriptions.receiveMaxAmountOfSamples,function(done) {
        test.receiveMaxAmountOfSamples(done);
      }).timeout(10000);


### PR DESCRIPTION
… hdfs-namenode

Signed-off-by: Marcel Wagner <wagmarcel@web.de>