### PR TITLE
Quickfix: removed wrong link for prometheus setup in Kafka-cluster

### DIFF
--- a/util/restart-cluster.sh
+++ b/util/restart-cluster.sh
@@ -29,7 +29,7 @@ printf -- "------------------------\033[0m\n"
 kubectl create -f https://github.com/minio/minio-operator/blob/master/minio-operator.yaml?raw=true --validate=false
 helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com/
 kubectl create ns kafka
-helm install kafka-operator --namespace=kafka banzaicloud-stable/kafka-operator -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/example-prometheus-alerts.yaml
+helm install kafka-operator --namespace=kafka banzaicloud-stable/kafka-operator
 kubectl create ns zookeeper
 helm install zookeeper-operator --namespace=zookeeper banzaicloud-stable/zookeeper-operator
 printf -- "\033[1mOperators installed successfully.\033[0m\n"


### PR DESCRIPTION
Signed-off-by: Marcel Wagner <wagmarcel@web.de>