### PR TITLE
* Changed MQTT Service to Headeless to support better loadbalancing

### DIFF
--- a/kubernetes/templates/mqtt.yaml
+++ b/kubernetes/templates/mqtt.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   ports:
   - port: 8883
+  clusterIP: None
   selector:
     app: mqtt-server
-
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -23,7 +23,6 @@ spec:
   selector:
     matchLabels:
       app: mqtt-server
-
   template:
     metadata:
       creationTimestamp: null
@@ -126,7 +125,6 @@ spec:
           readOnly: true
       imagePullSecrets:
       - name: dockercred
-      hostname: mqtt-server
       volumes:
       - name: jwt-keys
         secret:

--- a/util/get_oisp_credentials.sh
+++ b/util/get_oisp_credentials.sh
@@ -8,7 +8,7 @@ export POSTGRES_SU_PASSWORD=$(kubectl -n ${NAMESPACE} get -o yaml configmaps ois
 export POSTGRES_PASSWORD=$(kubectl -n ${NAMESPACE} get -o yaml configmaps oisp-config | shyaml get-value data.postgres | jq -r .password)
 export KEYCLOAK_PASSWORD=$(kubectl -n ${NAMESPACE} get -o yaml configmaps oisp-config | shyaml get-value data.keycloak-admin | jq -r .password)
 export KEYCLOAK_FRONTEND_SECRET=$(kubectl -n ${NAMESPACE} get -o yaml configmaps oisp-config | shyaml get-value data.keycloak | jq -r .secret)
-export KEYCLOAK_MQTT_BROKER_SECRET=$(kubectl -n ${NAMESPACE} get -o yaml configmaps oisp-config | shyaml get-value data.keycloak | jq -r .mqtt-broker-secret)
+export KEYCLOAK_MQTT_BROKER_SECRET=$(kubectl -n ${NAMESPACE} get -o yaml configmaps oisp-config | shyaml get-value data.keycloak | jq -r '.["mqtt-broker-secret"]')
 # tr "." "_" because jq cannot handle keys with "."
 export JWT_PRIVATE=$(kubectl -n ${NAMESPACE} -o json get secret oisp-secrets | tr "." "_" | jq -r .data.jwt_privatekey)
 export JWT_PUBLIC=$(kubectl -n ${NAMESPACE} -o json get secret oisp-secrets | tr "." "_" | jq -r .data.jwt_publickey)


### PR DESCRIPTION
* Fixed problem when reading out secrets during upgrade: jq does not accept dashes in field names and needs thus proper masking

Signed-off-by: Marcel Wagner <wagmarcel@web.de>