### PR TITLE
Tests for new aggregation and ordering function in search API. Added …

### DIFF
--- a/tests/oisp-tests.js
+++ b/tests/oisp-tests.js
@@ -917,7 +917,7 @@ describe("Creating and getting components ... \n".bold, function() {
 
 describe("Creating rules ... \n".bold, function() {
     before(function(){
-        if (checkTestCondition(["non_essential", "rules"])) {
+        if (checkTestCondition(["non_essential"])) {
             this.skip();
         }
     });
@@ -982,7 +982,7 @@ describe("Creating rules ... \n".bold, function() {
 });
 describe("Sending observations and checking rules ...\n".bold, function() {
     before(function(){
-            if (checkTestCondition(["non_essential", "rules", "data_sending"])) {
+            if (checkTestCondition(["non_essential", "data_sending"])) {
                 this.skip();
             }
     });
@@ -1273,6 +1273,12 @@ describe("Do data sending subtests ...".bold, function() {
      it(descriptions.sendDataAsUser,function(done) {
        test.sendDataAsUser(done);
      }).timeout(10000);
+     it(descriptions.send8000SamplesForAutoDownsampleTest,function(done) {
+       test.send8000SamplesForAutoDownsampleTest(done);
+     }).timeout(100000);
+     /*it(descriptions.send8000SamplesForMultiAggregationTest,function(done) {
+       test.send8000SamplesForMultiAggregationTest(done);
+     }).timeout(100000);*/
      it(descriptions.waitForBackendSynchronization,function(done) {
        // Due to low profile of test environment and the fact that Kafka/Backend is processing all the 1000s of samples
        // separately, we need to give the backend more time to settle
@@ -1289,6 +1295,42 @@ describe("Do data sending subtests ...".bold, function() {
      }).timeout(10000);
      it(descriptions.receiveDataFromAdmin,function(done) {
        test.receiveDataFromAdmin(done);
+     }).timeout(10000);
+     it(descriptions.receiveRawData,function(done) {
+       test.receiveRawData(done);
+     }).timeout(10000);
+     it(descriptions.receiveMaxItems,function(done) {
+       test.receiveMaxItems(done);
+     }).timeout(10000);
+     it(descriptions.receiveAutoAggregatedAvgData,function(done) {
+       test.receiveAutoAggregatedAvgData(done);
+     }).timeout(10000);
+     it(descriptions.receiveAutoAggregatedMaxData,function(done) {
+       test.receiveAutoAggregatedMaxData(done);
+     }).timeout(10000);
+     it(descriptions.receiveAutoAggregatedMinData,function(done) {
+       test.receiveAutoAggregatedMinData(done);
+     }).timeout(10000);
+     it(descriptions.receiveAutoAggregatedSumData,function(done) {
+       test.receiveAutoAggregatedSumData(done);
+     }).timeout(10000);
+     it(descriptions.receiveAggregatedAvgData,function(done) {
+       test.receiveAggregatedAvgData(done);
+     }).timeout(10000);
+     it(descriptions.receiveAggregatedAvgDataMS,function(done) {
+       test.receiveAggregatedAvgDataMS(done);
+     }).timeout(10000);
+     it(descriptions.receiveAggregatedAvgDataMinutes,function(done) {
+       test.receiveAggregatedAvgDataMinutes(done);
+     }).timeout(10000);
+     it(descriptions.receiveRawDataDesc,function(done) {
+       test.receiveRawDataDesc(done);
+     }).timeout(10000);
+     it(descriptions.receiveRawDataLatest,function(done) {
+       test.receiveRawDataLatest(done);
+     }).timeout(10000);
+     it(descriptions.receiveAggregatedDataFromMultipleComponents,function(done) {
+       test.receiveAggregatedDataFromMultipleComponents(done);
      }).timeout(10000);
      it(descriptions.cleanup,function(done) {
        test.cleanup(done);

--- a/tests/subtests/promise-wrap.js
+++ b/tests/subtests/promise-wrap.js
@@ -248,7 +248,19 @@ var submitData = function(value, deviceToken, accountId, deviceId, cid){
 
 var searchData = function(from, to, userToken, accountId, deviceId, cid, queryMeasureLocation, targetFilter){
     return new Promise((resolve, reject) => {
-	helpers.data.searchData(from, to, userToken, accountId, deviceId, cid, queryMeasureLocation, targetFilter, function(err, response){
+	    helpers.data.searchData(from, to, userToken, accountId, deviceId, cid, queryMeasureLocation, targetFilter, function(err, response){
+	    if (err) {
+		reject(err);
+	    } else {
+		resolve(response);
+	    }
+	});
+    });
+}
+
+var searchDataMaxItems = function(from, to, userToken, accountId, deviceId, cids, queryMeasureLocation, targetFilter, maxItems, order, aggregators){
+    return new Promise((resolve, reject) => {
+	helpers.data.searchDataMaxItems(from, to, userToken, accountId, deviceId, cids, queryMeasureLocation, targetFilter, maxItems, order, aggregators, function(err, response){
 	    if (err) {
 		reject(err);
 	    } else {
@@ -503,6 +515,7 @@ module.exports = {
     submitDataListAsUser: submitDataListAsUser,
     submitData: submitData,
     searchData: searchData,
+    searchDataMaxItems: searchDataMaxItems,
     searchDataAdvanced: searchDataAdvanced,
     authGetToken: authGetToken,
     refreshAuthToken: refreshAuthToken,


### PR DESCRIPTION
…test for:

* Autoaggregation if no explicit sampling is provided and there are more samples than the allowed number
* Autoaggregation if no explicit sampling and maxitems is smaller than requested amount of points
* Aggregation with explicit sampling
* Getting raw data from the oldest to max number of samples in default order "asc"
* Getting raw data from newest to oldest one until max amount of samples with reverse order "desc"
* MaxItems limitation of raw samples
* Test unit types "millisecond", "second", "minutes", "hours"
* Test aggregator types "avg", "max", "min", "sum"
* Test with two components with each having different aggregator

Signed-off-by: Marcel Wagner <wagmarcel@web.de>