### PR TITLE
prep-test is now part of the main test. Reason: prep-test-only is use…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ prepare-tests: wait-until-ready
 ## test: Run tests
 ##
 test: OISP_TESTS_SKIP_SCALE ?= "true"
-test: prepare-tests
+test: prepare-tests test-prep-only
 	kubectl -n $(NAMESPACE) exec $(DEBUGGER_POD) -c debugger \
 		-- /bin/bash -c "cd /home/$(CURRENT_DIR_BASE)/tests && make test TERM=xterm NAMESPACE=$(NAMESPACE) OISP_TESTS_SKIP_SCALE=$(OISP_TESTS_SKIP_SCALE)"
 

--- a/tests/oisp-prep-only.js
+++ b/tests/oisp-prep-only.js
@@ -123,7 +123,7 @@ describe("Waiting for OISP services to be ready ...\n".bold, function() {
             }
         });
 
-    }).timeout(2 * 60 * 1000);
+    }).timeout(1000 * 60 * 1000);
 })
 
 describe("get authorization and manage user ...\n".bold, function() {


### PR DESCRIPTION
…d for iot-agent tests and thus we need to keep an eye on it.

Signed-off-by: Marcel Wagner <wagmarcel@web.de>