### PR TITLE
Backup and restore for postgres, configmaps and secrets

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to Open IoT Service Platform's documentation!
    :caption: Contents:
 
    usage/quickstart
+   usage/backup
    development/developers_guide
 
 Indices and tables

--- a/docs/usage/backup.rst
+++ b/docs/usage/backup.rst
@@ -1,0 +1,17 @@
+Backup and Restore
+==================
+
+Backup and Restore options are provided by the Makefile.
+
+.. code-block:: bash
+
+  make backup
+  make restore BACKUPFILE=file.tgz
+
+
+Backup creates a tgz in folder backups with the current date and time. It contains the postgres DB backup, (selected) configmaps, (selected) secrets, and a list of deployment/statefuleset images and docker tags.
+It does NOT backup the TSDB (yet). So if all is restored in a clean new installation, the metrics will be missed.
+
+Restore is either using the tgz provided in the env variable BACKUPFILE, or it will select the most recent backup.
+The backup is changing the passwords for Postgres users. Therefore, both, running keycloak and frontend pods have to be deleted. Grafana password is not reset. Therefore there will be a mismatch between grafana and frontend.
+To solve it, the grafana deployment has to be removed and redeployed with ``make upgrade-oisp``.

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -42,6 +42,7 @@ If you have access to the OISP dockerhub repository, export your user credential
 
   export DOCKERUSER=[YOURUSERNAME]
   read -s DOCKERPASS # type your password and press enter
+  export DOCKERPASS
 
 Otherwise, you will have to build the images yourself. Go to the project root and run ``make update && make build``.
 You can specify a docker tag for the images being built. Run ``make help`` for more details. Afterwards, you have two options to get the images inside the cluster:

--- a/scripts/cm_check.sh
+++ b/scripts/cm_check.sh
@@ -1,0 +1,103 @@
+#! /bin/bash
+# compares configmaps and secrets from a backup and K8s deployment
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmdname=$(basename $0)
+#DEBUG=true # uncomment to switch on debug
+
+
+# list deployments and sfs with their image tags
+# parameters: <type> <namespace>
+# type: "deployment" or "statefulsets"
+# return pairs of name,image_name
+list_images()
+{
+  local TYPE=$1
+  local NAMESPACE=$2
+  # dump deployment and StatefulSet
+  local NAMES=($(kubectl -n ${NAMESPACE} get ${TYPE} -o jsonpath={...spec.template.spec.containers[*].name}))
+  local IMAGES=($(kubectl -n ${NAMESPACE} get ${TYPE} -o jsonpath={...spec.template.spec.containers[*].image}))
+
+  RETURNVAL=()
+  for index in "${!NAMES[@]}";
+  do
+    RETURNVAL+=("${NAMES[$index]},${IMAGES[$index]}")
+  done
+  echo ${RETURNVAL[@]}
+}
+
+
+# check whether array and file are identical
+# parameters: <array> <filename>
+# array: array name of array which is compared
+# filename: filename of file to be compared with array
+# return "true" or "false"
+check_equal()
+{
+  local -n ARRAY=$1
+  local FILENAME=$2
+  RET="true"
+  index=0
+  while read -r line; do
+    if [ ! "$line" = "${ARRAY[$index]}" ]; then
+      RET="false"
+    fi
+    (( index++ ))
+  done < ${FILENAME}
+
+  echo $RET
+}
+
+usage()
+{
+    cat << USAGE >&2
+
+Checks configmaps and secrets of a backup and compares with namespace
+
+Usage:
+
+    $cmdname  <tmpdir> <namespace>
+
+    tmpdir: directory where the configmaps and secrets are dumped to. File will be tmpdir/cmname or tmpdir/secretname
+    namespace: namespace to compare with
+USAGE
+    exit 1
+}
+
+if [ "$#" -ne 2 ] || [ "$1" = "-h" ] ;
+then
+    usage
+fi
+
+TMPDIR=$1
+NAMESPACE=$2
+
+# first check whether the name,image pairs match
+DEPLOYMENTS_COMP=($(list_images deployments ${NAMESPACE}| tr " " "\n" | sort | uniq))
+SFS_COMP=($(list_images statefulsets ${NAMESPACE} | tr " " "\n" | sort | uniq))
+RESULT1=$(check_equal DEPLOYMENTS_COMP ${TMPDIR}/deployments)
+RESULT2=$(check_equal SFS_COMP ${TMPDIR}/statefulsets)
+
+if [ "$RESULT1" = "false" ] || [ "$RESULT2" = "false" ]; then
+  while true; do
+      read -p "Mismatch detected between deployments and statefulsets. Be aware that this could affect the compatibility. Continue?" yn
+      case $yn in
+          [Yy]* ) break;;
+          [Nn]* ) exit 1;;
+          * ) echo "Please answer yes or no.";;
+      esac
+  done
+fi

--- a/scripts/cm_dump.sh
+++ b/scripts/cm_dump.sh
@@ -1,0 +1,185 @@
+#! /bin/bash
+# dumps configmaps and secrets of a namespace into folder
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmdname=$(basename $0)
+DEBUG=true # uncomment to switch on debug
+REMOVEFIELDS=(creationTimestamp resourceVersion uid selfLink)
+
+# filter out the EXCLUDED and remove '""'
+# Parameters: <ARRAY> <EXCLUDED>
+filter()
+{
+  local -n ARRAY=$1
+  local -n EXCL=$2
+  if [ "${DEBUG}" = "true" ]; then
+    echo parameters of filter:
+    echo ARRAY = ${ARRAY[@]}
+    echo EXCLUDED = ${EXCL[@]}
+  fi
+  #remove '""'
+  for index in ${!ARRAY[*]}; do
+    ARRAY[$index]=$(sed -e 's/^"//' -e 's/"$//' <<<${ARRAY[$index]})
+  done
+
+  # remove excluded
+  for del in ${EXCL[@]}; do
+    for index in ${!ARRAY[*]}; do
+      if [[ "${ARRAY[$index]}" =  $del* ]]; then
+        unset ARRAY[$index]
+      fi
+    done
+  done
+}
+
+
+# remove not needed fields from K8s objects
+# such as creationTimestamp, resourceVersion, uid, selfLink
+# parameters: <filename> <array>
+remove_fields()
+{
+  local FILENAME=$1
+  local -n RMFLDS=$2
+
+  if [ "${DEBUG}" = "true" ]; then
+    echo parameters of remove_fields:
+    echo FILENAME = ${FILENAME}
+    echo RMFLDS = ${RMFLDS[@]}
+  fi
+
+  for field in ${RMFLDS[@]}; do
+    jq "del (.metadata.$field)" ${FILENAME} > ${FILENAME}2
+    mv ${FILENAME}2 ${FILENAME}
+  done
+
+}
+
+
+# list deployments and sfs with their image tags
+# parameters: <type>
+# type: "deployment" or "statefulsets"
+# return pairs of name,image_name
+list_images()
+{
+  local TYPE=$1
+  # dump deployment and StatefulSet
+  local NAMES=($(kubectl -n oisp get ${TYPE} -o jsonpath={...spec.template.spec.containers[*].name}))
+  local IMAGES=($(kubectl -n oisp get ${TYPE} -o jsonpath={...spec.template.spec.containers[*].image}))
+
+  RETURNVAL=()
+  for index in "${!NAMES[@]}";
+  do
+    RETURNVAL+=("${NAMES[$index]},${IMAGES[$index]}")
+  done
+
+  echo ${RETURNVAL[@]}
+}
+
+
+usage()
+{
+    cat << USAGE >&2
+
+Dumps configmaps and secrets of a namespace into folder
+
+Usage:
+
+    $cmdname  <tmpdir> <namespace> <exclude>
+
+    tmpdir: directory where the configmaps and secrets are dumped to. File will be tmpdir/cmname or tmpdir/secretname
+    namespace: K8s namespace where db is located
+    exclude: List of prefixes which should be excluded from backup, list is in quotes and seperated by space e.g "sh.helm dummy"
+USAGE
+    exit 1
+}
+
+if [ "$#" -ne 3 ] || [ "$1" = "-h" ] ;
+then
+    usage
+fi
+
+TMPDIR=$1
+NAMESPACE=$2
+EXCLUDED=($3)
+
+RAWCMLIST=$(kubectl -n ${NAMESPACE} get cm -o json| jq '.items[].metadata.name'| tr '\n' ' ')
+IFS=' ' read -r -a CMARRAY <<< "$RAWCMLIST"
+RAWSECRETLIST=$(kubectl -n ${NAMESPACE} get secret -o json| jq '.items[].metadata.name'| tr '\n' ' ')
+IFS=' ' read -r -a SECRETARRAY <<< "$RAWSECRETLIST"
+
+filter CMARRAY EXCLUDED
+filter SECRETARRAY EXCLUDED
+
+# debug output
+if [ "${DEBUG}" = "true" ]; then
+  echo main parameters:
+  echo TMPDIR = ${TMPDIR}
+  echo NAMESPACE = ${NAMESPACE}
+  echo EXLUDED = ${EXCLUDED[@]}
+  echo CMARRAY = ${CMARRAY[@]}
+  echo SECRETARRAY = ${SECRETARRAY[@]}
+fi
+
+# create working_directory
+mkdir -p ${TMPDIR}
+
+# check if one of the cm already exists
+for element in "${CMARRAY[@]}"
+do
+    if [ -f ${TMPDIR}/${element} ]; then
+      echo Configmap ${element} already in ${TMPDIR} - not overwriting - Bye
+      exit 1
+    fi
+done
+
+# check if one of the secrets already exists
+for element in "${SECRETARRAY[@]}"
+do
+    if [ -f ${TMPDIR}/${element} ]; then
+      echo Secret ${element} already in ${TMPDIR} - not overwriting - Bye
+      exit 1
+    fi
+done
+
+# write cm into folder
+echo Dump configmaps of ${NAMESPACE}
+for element in "${CMARRAY[@]}"
+do
+  kubectl -n ${NAMESPACE} get cm/${element} -o json > ${TMPDIR}/${element}.json
+  remove_fields ${TMPDIR}/${element}.json REMOVEFIELDS
+done
+
+
+# write secret into folder
+echo Dump secrets of ${NAMESPACE}
+for element in "${SECRETARRAY[@]}"
+do
+  kubectl -n ${NAMESPACE} get secret/${element} -o json > ${TMPDIR}/${element}.json
+  remove_fields ${TMPDIR}/${element}.json REMOVEFIELDS
+done
+
+# create name,image list for  DEPLOYMENTS and STATEFULSETS
+DEPLOYMENTS=($(list_images deployments))
+SFS=($(list_images statefulsets))
+
+if [ "${DEBUG}" = "true" ]; then
+  echo DEPLOYMENTS = ${DEPLOYMENTS[@]}
+  echo SFS = ${SFS[@]}
+fi
+
+# write name,image lists to folder
+echo ${DEPLOYMENTS[@]} | tr " " "\n"| sort | uniq > ${TMPDIR}/deployments
+echo ${SFS[@]} | tr " " "\n"| sort |   uniq > ${TMPDIR}/statefulsets

--- a/scripts/cm_restore.sh
+++ b/scripts/cm_restore.sh
@@ -1,0 +1,81 @@
+#! /bin/bash
+# restores configmaps and secrets of a namespace taken from a folder
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+cmdname=$(basename $0)
+#DEBUG=true # uncomment to switch on debug
+
+
+
+usage()
+{
+    cat << USAGE >&2
+
+Dumps configmaps and secrets of a namespace into folder
+
+Usage:
+
+    $cmdname  <tmpdir> <namespace>
+
+    tmpdir: directory where the configmaps and secrets are dumped to. File will be tmpdir/cmname or tmpdir/secretname
+    namespace: k8s namespace
+USAGE
+    exit 1
+}
+
+if [ "$#" -ne 2 ] || [ "$1" = "-h" ] ;
+then
+    usage
+fi
+
+TMPDIR=$1
+NAMESPACE=$2
+# we need again DB access. Because we need to change the db user passwords accourding to the new config
+BNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".dbname")
+SUPERUSERNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".su_username")
+SUPERPASSWORD=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".su_password")
+HOSTNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".hostname")
+
+OISPCONFIG=($(ls ${TMPDIR}/oisp-config.json))
+
+# sanity test. This file musst exist in a sane backup
+if [ ! -f "${OISPCONFIG}" ]; then
+  echo oisp-config.json not found in db backup. Bye!
+  exit 1;
+fi
+
+
+K8SOBJECTS=($(ls ${TMPDIR}/*.json))
+
+# debug output
+if [ "${DEBUG}" = "true" ]; then
+  echo main parameters:
+  echo TMPDIR = ${TMPDIR}
+  echo K8SOBJECTS = ${K8SOBJECTS[@]}
+fi
+
+# sanity check: If one of paramters is empty - stop
+if [ "${#K8SOBJECTS[@]}" -eq 0 ]; then
+  echo paramters not healthy. K8SOBJECTS is empty - Bye
+  exit 1
+fi
+
+# check if one of the cm already exists
+for element in "${K8SOBJECTS[@]}"
+do
+    kubectl replace -f $element
+done

--- a/scripts/db_dump.sh
+++ b/scripts/db_dump.sh
@@ -1,0 +1,76 @@
+#! /bin/bash
+# dumps database to tmp directory
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+cmdname=$(basename $0)
+#DEBUG=true # uncomment to switch on debug
+DUMPFILE=database.sql
+CONTAINER=oisp-stolon-keeper-0
+
+usage()
+{
+    cat << USAGE >&2
+
+Dumps postgres database to temp directory
+
+Usage:
+
+    $cmdname  <tmpdir> <namespace>
+
+    tmpdir: directory where the database is dumped to. File will be tmpdir/database.sql
+    namespace: K8s namespace where db is located
+USAGE
+    exit 1
+}
+
+if [ "$#" -ne 2 ] || [ "$1" = "-h" ] ;
+then
+    usage
+fi
+
+TMPDIR=$1
+NAMESPACE=$2
+DBNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".dbname")
+USERNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".su_username")
+PASSWORD=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".su_password")
+HOSTNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".hostname")
+
+if [ "${DEBUG}" = "true" ]; then
+  echo parameters:
+  echo TMPDIR = ${TMPDIR}
+  echo NAMESPACE = ${NAMESPACE}
+  echo DBNAME = ${DBNAME}
+  echo USERNAME = ${USERNAME}
+  echo PASSWORD = ${PASSWORD}
+  echo HOSTNAME = ${HOSTNAME}
+fi
+
+# sanity check: If one of paramters is empty - stop
+if [ -z "${USERNAME}" ] || [ -z "${DBNAME}" ] || [ -z "${PASSWORD}" ] || [ -z "${HOSTNAME}" ]; then
+  echo paramters not healthy. Some are empty - Bye
+  exit 1
+fi
+# create dir
+mkdir -p ${TMPDIR}
+# if file exists, exit
+if [ -f "${TMPDIR}/${DUMPFILE}" ]; then
+  echo file alredy exists - will not overwriet - Bye
+  exit 1
+fi
+
+echo Dump database
+kubectl -n ${NAMESPACE} exec ${CONTAINER} -- /bin/bash -c "export PGPASSWORD=${PASSWORD}; pg_dump -U ${USERNAME} ${DBNAME} -h ${HOSTNAME} -F c -b " > ${TMPDIR}/${DUMPFILE}

--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -1,0 +1,113 @@
+#! /bin/bash
+# restore database
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmdname=$(basename $0)
+DEBUG=true # uncomment to switch on debug
+DUMPFILE=database.sql
+CONTAINER=oisp-stolon-keeper-0
+
+
+# read fields from oisp-config (what is the problem? the 3rd level objects are saved as string and, thus, tough to parse as JSON)
+# parameters: <filename> <field>
+read_postgres_oisp_config(){
+  local FILENAME=$1
+  local FIELD=$2
+
+  # hmmm
+  # get the json string,
+  # remove outer quotes,
+  # let echo interprete the \n,
+  # replace \"
+  # then parse with jq, replace outer quotes
+  echo -e $(jq ".data.postgres" ${FILENAME} | sed 's/^"\(.*\)"$/\1/g') | sed 's/\\"/"/g' | jq ".${FIELD}" | sed 's/^"\(.*\)"$/\1/g'
+}
+
+
+usage()
+{
+    cat << USAGE >&2
+
+Dumps postgres database to temp directory
+
+Usage:
+
+    $cmdname  <tmpdir> <namespace>
+
+    tmpdir: directory where the database.sql and oisp-config can be found
+    namespace: K8s namespace where db is located
+USAGE
+    exit 1
+}
+
+if [ "$#" -ne 2 ] || [ "$1" = "-h" ] ;
+then
+    usage
+fi
+
+TMPDIR=$1
+NAMESPACE=$2
+DBNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".dbname")
+USERNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".su_username")
+PASSWORD=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".su_password")
+HOSTNAME=$(kubectl -n oisp get cm/oisp-config -o jsonpath='{..postgres}'| jq ".hostname")
+
+if [ ${DEBUG} = "true" ]; then
+  echo parameters:
+  echo TMPDIR = ${TMPDIR}
+  echo NAMESPACE = ${NAMESPACE}
+  echo DBNAME = ${DBNAME}
+  echo USERNAME = ${USERNAME}
+  echo PASSWORD = ${PASSWORD}
+  echo HOSTNAME = ${HOSTNAME}
+fi
+
+# sanity check: If one of paramters is empty - stop
+if [ -z "${USERNAME}" ] || [ -z "${DBNAME}" ] || [ -z "${PASSWORD}" ] || [ -z "${HOSTNAME}" ]; then
+  echo USERNAME is empty - Bye
+  exit 1
+fi
+
+# if file does not exists, exit
+if [ ! -f "${TMPDIR}/${DUMPFILE}" ]; then
+  echo ${DUMPFILE} does not exists - Bye
+  exit 1
+fi
+
+# retrieve new passwords
+echo set new passwords
+OISPCONFIG=($(ls ${TMPDIR}/oisp-config.json))
+# sanity test. This file musst exist in a sane backup
+if [ ! -f "${OISPCONFIG}" ]; then
+  echo oisp-config.json not found in db backup. Bye!
+  exit 1;
+fi
+NEW_USERPASSWORD=$(read_postgres_oisp_config ${OISPCONFIG} password)
+NEW_SUPERPASSWORD=$(read_postgres_oisp_config ${OISPCONFIG} su_password)
+# sanity check: If one of paramters is empty - stop
+if [ -z "${NEW_USERPASSWORD}" ] || [ -z "${NEW_SUPERPASSWORD}" ]; then
+  echo NEW_PASSWORDS are empty - Bye
+  exit 1
+fi
+
+echo "ALTER USER oisp_user WITH PASSWORD '${NEW_USERPASSWORD}';" | kubectl -n ${NAMESPACE} exec -i ${CONTAINER} -- /bin/bash -c "export PGPASSWORD=${PASSWORD}; psql -U ${USERNAME}  -d ${DBNAME} -h ${HOSTNAME}"
+echo "ALTER USER superuser WITH PASSWORD '${NEW_SUPERPASSWORD}';" | kubectl -n ${NAMESPACE} exec -i ${CONTAINER} -- /bin/bash -c "export PGPASSWORD=${PASSWORD}; psql -U ${USERNAME}  -d ${DBNAME} -h ${HOSTNAME}"
+
+echo restore database
+kubectl -n ${NAMESPACE} exec -i ${CONTAINER} -- /bin/bash -c "export PGPASSWORD=${NEW_SUPERPASSWORD}; pg_restore -c -U ${USERNAME}  -d ${DBNAME} -h ${HOSTNAME}" < ${TMPDIR}/${DUMPFILE}
+
+echo set user rights
+# retrieve new passwords and users

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,8 +22,8 @@ SHELL:=/bin/bash
 MAKEFILE_DIR := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURRENT_DIR  :=  $(patsubst %/,%,$(dir $(MAKEFILE_DIR)))
 
-USERNAME = "oisp@testing.com"
-PASSWORD = "OispTesting1"
+USERNAME?="oisp@testing.com"
+PASSWORD?="OispTesting1"
 
 USERNAME2 = "oisp2@testing.com"
 PASSWORD2 = "OispTesting2"
@@ -53,6 +53,17 @@ test: npm-install
 	@$(call msg,"Starting the e2e testing ... $$TEST_PREP_ONLY");
 	@env http_proxy="" https_proxy="" USERNAME=$(USERNAME) PASSWORD=$(PASSWORD) USERNAME2=$(USERNAME2) PASSWORD2=$(PASSWORD2) LOG_LEVEL="error" NODE_ENV="local" npm test
 
+test-backup-before: npm-install
+	@export OISP_GRAFANA_PASSWORD=$$(kubectl -n $(NAMESPACE) get -o yaml configmaps oisp-config | shyaml get-value data.grafana | jq -r .adminPassword) && \
+	cat test-config-template.json | envsubst > test-config.json
+	@$(call msg,"Starting backup test before ...");
+	@env http_proxy="" https_proxy="" USERNAME=$(USERNAME) PASSWORD=$(PASSWORD) LOG_LEVEL="error" NODE_ENV="local" npm run-script test-backup-before
+
+test-backup-after: npm-install
+	@export OISP_GRAFANA_PASSWORD=$$(kubectl -n $(NAMESPACE) get -o yaml configmaps oisp-config | shyaml get-value data.grafana | jq -r .adminPassword) && \
+	cat test-config-template.json | envsubst > test-config.json
+	@$(call msg,"Starting backup test before ...");
+	@env http_proxy="" https_proxy="" USERNAME=$(USERNAME) PASSWORD=$(PASSWORD) LOG_LEVEL="error" NODE_ENV="local" npm run-script test-backup-after
 
 clean:
 	@$(call msg,"Cleaning ...");

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,9 @@
   "main": "test.js",
   "scripts": {
     "test": "mocha oisp-tests.js --exit",
-    "prep-only": "mocha oisp-prep-only.js --exit"
+    "prep-only": "mocha oisp-prep-only.js --exit",
+    "test-backup-before": "mocha test-backup-before.js --exit",
+    "test-backup-after": "mocha test-backup-after.js --exit"
   },
   "author": "Intel SSG-DRD",
   "license": "ISC",

--- a/tests/test-backup-after.js
+++ b/tests/test-backup-after.js
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+var chai = require('chai');
+var assert = chai.assert;
+var fs = require('fs');
+var { Data, Rule, Component, Components } = require('./lib/common');
+
+var config = require("./test-config.json");
+var kafka = require('kafka-node');
+var helpers = require("./lib/helpers");
+var colors = require('colors');
+var promtests = require('./subtests/promise-wrap');
+
+
+var accountName = "oisp-tests";
+
+var userToken;
+var deviceToken;
+var accountId = process.env.ACCOUNTID;
+var deviceId;
+var deviceName = "backup-tests-device";
+var activationCode = process.env.ACTIVATIONCODE;
+var userId;
+var username = process.env.USERNAME;
+var password = process.env.PASSWORD;
+
+var componentId;
+var componentType = "temperature.v1.0";
+var componentName = "temp;"
+
+var getNewUserTokens = function(done) {
+
+    return promtests.authGetToken(username, password).then(grant => {
+        userToken = grant.token;
+        done();
+    }).catch(err => {
+        done(err);
+    });
+};
+//-------------------------------------------------------------------------------------------------------
+// Tests
+//-------------------------------------------------------------------------------------------------------
+process.stdout.write("_____________________________________________________________________\n".bold);
+process.stdout.write("                                                                     \n");
+process.stdout.write("                           OISP Backup Test after                    \n".green.bold);
+process.stdout.write("_____________________________________________________________________\n".bold);
+
+
+
+describe("Waiting for OISP services to be ready ...\n".bold, function() {
+
+    before(function(done) {
+        userToken = null;
+        deviceId = "00-12-23-34-45-56";
+        done();
+    });
+
+    it('Shall wait for oisp services to start', function(done) {
+        var kafkaConsumer;
+        var topic = config["connector"]["kafka"]["topic"];
+        var partition = 0;
+        var kafkaAddress = config["connector"]["kafka"]["host"] + ":" + config["connector"]["kafka"]["port"];
+        var kafkaClient = new kafka.KafkaClient({ kafkaHost: kafkaAddress });
+        var kafkaOffset = new kafka.Offset(kafkaClient);
+
+        var getKafkaOffset = function(topic_, partition_, cb) {
+            kafkaOffset.fetchLatestOffsets([topic_], function(error, offsets) {
+                if (!error) {
+                    cb(offsets[topic_][partition_])
+                }
+                else {
+                    setTimeout(function() {
+                        getKafkaOffset(topic_, partition_, cb);
+                    }, 1000)
+                }
+            })
+        };
+
+        getKafkaOffset(topic, partition, function(offset) {
+            if (offset >= 0) {
+                var topics = [{ topic: topic, offset: offset + 1, partition: partition }]
+                var options = { autoCommit: true, fromOffset: true };
+
+                kafkaConsumer = new kafka.Consumer(kafkaClient, topics, options)
+
+                var oispServicesToMonitor = ['rules-engine'];
+                process.stdout.write("    ");
+                kafkaConsumer.on('message', function(message) {
+                    process.stdout.write(".".green);
+                    if (kafkaConsumer) {
+                        var now = new Date().getTime();
+                        var i = 0;
+                        for (i = 0; i < oispServicesToMonitor.length; i++) {
+                            if (oispServicesToMonitor[i] != null && oispServicesToMonitor[i].trim() === message.value.trim()) {
+                                oispServicesToMonitor[i] = null;
+                            }
+                        }
+                        for (i = 0; i < oispServicesToMonitor.length; i++) {
+                            if (oispServicesToMonitor[i] != null) {
+                                break;
+                            }
+                        }
+                        if (i == oispServicesToMonitor.length) {
+                            kafkaConsumer.close(true);
+                            kafkaConsumer = null;
+                            process.stdout.write("\n");
+                            done();
+                        }
+                    }
+                });
+            }
+            else {
+                done(new Error("Cannot get Kafka offset "))
+            }
+        });
+
+    }).timeout(1000 * 60 * 1000);
+})
+
+describe("get authorization and manage user ...\n".bold, function() {
+
+    it('Shall authenticate', function(done) {
+        getNewUserTokens(done);
+    }).timeout(10000);
+
+    it('Shall get token info', function (done) {
+        helpers.auth.tokenInfo(userToken, function (err, response) {
+            if (err) {
+                done(new Error("Cannot get token info: " + err));
+            } else {
+                assert.equal(response.header.typ, 'JWT', 'response type error' );
+                if (response.payload.sub == null){
+                    done(new Error("get null user id"));
+                }
+                else {
+                    userId = response.payload.sub;
+                }
+
+                    done();
+            }
+        })
+    })
+
+    it('Shall get user information', function(done) {
+        helpers.users.getUserInfo(userToken, userId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot get user information : " + err));
+            } else {
+                assert.isString(response.id)
+                done();
+            }
+        })
+    })
+
+})
+
+describe("Check account and device ...\n".bold, function() {
+
+    var accountInfo;
+
+    it('Shall retrieve account info', function(done) {
+        helpers.accounts.getAccountInfo(accountId, userToken, function(err, response) {
+            if (err) {
+                done(new Error("Cannot get user info: " + err));
+            } else {
+                assert.equal(accountId, response.id);
+                done();
+            }
+        })
+    }).timeout(10000);
+
+
+    it('Shall get devices', function(done) {
+
+        helpers.devices.getDevices(userToken, accountId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot create device: " + err));
+            } else {
+                assert.equal(response.length, 1);
+                assert.equal(response[0].deviceId, deviceId, 'incorrect device id');
+                assert.equal(response[0].name, deviceName, 'incorrect device name');
+                assert.equal(response[0].components[0].name, componentName);
+                assert.equal(response[0].components[0].type, componentType);
+                componentId = response[0].components[0].cid;
+                done();
+            }
+        })
+    })
+
+    it('Shall activate device without token', function(done) {
+        assert.notEqual(deviceId, null, "Invalid device id")
+
+        helpers.devices.activateDeviceWithoutToken(activationCode, deviceId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot activate device: " + err));
+            } else {
+                deviceToken = response.deviceToken;
+                done();
+            }
+        });
+    }).timeout(5000);
+
+    it('Shall send data point', function(done) {
+
+        helpers.devices.submitData("23", deviceToken, accountId, deviceId, componentId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot create device: " + err));
+            } else {
+                done();
+            }
+        })
+    }).timeout(10000);
+})

--- a/tests/test-backup-before.js
+++ b/tests/test-backup-before.js
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+var chai = require('chai');
+var assert = chai.assert;
+var fs = require('fs');
+var { Data, Rule, Component, Components } = require('./lib/common');
+
+var config = require("./test-config.json");
+var kafka = require('kafka-node');
+var helpers = require("./lib/helpers");
+var colors = require('colors');
+var promtests = require('./subtests/promise-wrap');
+
+
+var accountName = "oisp-tests";
+
+var userToken;
+var deviceToken;
+var accountId = process.env.ACCOUNTID;
+var deviceId;
+var deviceName = "backup-tests-device";
+var activationCode = process.env.ACTIVATIONCODE;
+var userId;
+var username = process.env.USERNAME;
+var password = process.env.PASSWORD;
+
+var componentId;
+var componentType = "temperature.v1.0";
+var componentName = "temp;"
+
+var getNewUserTokens = function(done) {
+
+    return promtests.authGetToken(username, password).then(grant => {
+        userToken = grant.token;
+        done();
+    }).catch(err => {
+        done(err);
+    });
+};
+//-------------------------------------------------------------------------------------------------------
+// Tests
+//-------------------------------------------------------------------------------------------------------
+process.stdout.write("_____________________________________________________________________\n".bold);
+process.stdout.write("                                                                     \n");
+process.stdout.write("                           OISP Backup Test before                   \n".green.bold);
+process.stdout.write("_____________________________________________________________________\n".bold);
+
+
+
+describe("Waiting for OISP services to be ready ...\n".bold, function() {
+
+    before(function(done) {
+        userToken = null;
+        deviceId = "00-12-23-34-45-56";
+        done();
+    });
+
+    it('Shall wait for oisp services to start', function(done) {
+        var kafkaConsumer;
+        var topic = config["connector"]["kafka"]["topic"];
+        var partition = 0;
+        var kafkaAddress = config["connector"]["kafka"]["host"] + ":" + config["connector"]["kafka"]["port"];
+        var kafkaClient = new kafka.KafkaClient({ kafkaHost: kafkaAddress });
+        var kafkaOffset = new kafka.Offset(kafkaClient);
+
+        var getKafkaOffset = function(topic_, partition_, cb) {
+            kafkaOffset.fetchLatestOffsets([topic_], function(error, offsets) {
+                if (!error) {
+                    cb(offsets[topic_][partition_])
+                }
+                else {
+                    setTimeout(function() {
+                        getKafkaOffset(topic_, partition_, cb);
+                    }, 1000)
+                }
+            })
+        };
+
+        getKafkaOffset(topic, partition, function(offset) {
+            if (offset >= 0) {
+                var topics = [{ topic: topic, offset: offset + 1, partition: partition }]
+                var options = { autoCommit: true, fromOffset: true };
+
+                kafkaConsumer = new kafka.Consumer(kafkaClient, topics, options)
+
+                var oispServicesToMonitor = ['rules-engine'];
+                process.stdout.write("    ");
+                kafkaConsumer.on('message', function(message) {
+                    process.stdout.write(".".green);
+                    if (kafkaConsumer) {
+                        var now = new Date().getTime();
+                        var i = 0;
+                        for (i = 0; i < oispServicesToMonitor.length; i++) {
+                            if (oispServicesToMonitor[i] != null && oispServicesToMonitor[i].trim() === message.value.trim()) {
+                                oispServicesToMonitor[i] = null;
+                            }
+                        }
+                        for (i = 0; i < oispServicesToMonitor.length; i++) {
+                            if (oispServicesToMonitor[i] != null) {
+                                break;
+                            }
+                        }
+                        if (i == oispServicesToMonitor.length) {
+                            kafkaConsumer.close(true);
+                            kafkaConsumer = null;
+                            process.stdout.write("\n");
+                            done();
+                        }
+                    }
+                });
+            }
+            else {
+                done(new Error("Cannot get Kafka offset "))
+            }
+        });
+
+    }).timeout(1000 * 60 * 1000);
+})
+
+describe("get authorization and manage user ...\n".bold, function() {
+
+    it('Shall authenticate', function(done) {
+        getNewUserTokens(done);
+    }).timeout(10000);
+
+    it('Shall get token info', function (done) {
+        helpers.auth.tokenInfo(userToken, function (err, response) {
+            if (err) {
+                done(new Error("Cannot get token info: " + err));
+            } else {
+                assert.equal(response.header.typ, 'JWT', 'response type error' );
+                if (response.payload.sub == null){
+                    done(new Error("get null user id"));
+                }
+                else {
+                    userId = response.payload.sub;
+                }
+
+                    done();
+            }
+        })
+    })
+
+    it('Shall get user information', function(done) {
+        helpers.users.getUserInfo(userToken, userId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot get user information : " + err));
+            } else {
+                assert.isString(response.id)
+                done();
+            }
+        })
+    })
+
+    it('Shall update user information', function(done) {
+        var newuserInfo = {
+            attributes:{
+                "phone":"123321",
+                "another_attribute":"another_attribute",
+                "new":"value"
+            }
+        }
+
+        helpers.users.updateUserInfo(userToken, userId, newuserInfo, function(err, response) {
+            if (err) {
+                done(new Error("Cannot update user information : " + err));
+            } else {
+                assert.equal(response.status, 'OK', 'status error')
+                done();
+            }
+        })
+    })
+})
+
+describe("Get account and create device ...\n".bold, function() {
+
+    var accountInfo;
+
+    it('Shall retrieve account info', function(done) {
+        helpers.accounts.getAccountInfo(accountId, userToken, function(err, response) {
+            if (err) {
+                done(new Error("Cannot get user info: " + err));
+            } else {
+                accountInfo = response;
+                done();
+            }
+        })
+    }).timeout(10000);
+
+
+    it('Shall update an account', function (done) {
+
+        accountInfo.attributes = {
+            "phone":"987654321",
+            "another_attribute":"this_value",
+            "new":"cur_string_value"
+        }
+
+        helpers.accounts.updateAccount(accountId, userToken, accountInfo, function (err, response) {
+            if (err) {
+                done(new Error("Cannot update account: " + err));
+            } else {
+                assert.deepEqual(response.attributes, accountInfo.attributes, 'new attributes not being updated');
+                done();
+            }
+        })
+    })
+
+
+    it('Shall create device', function(done) {
+        assert.notEqual(accountId, null, "Invalid account id")
+
+        helpers.devices.createDevice(deviceName, deviceId, userToken, accountId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot create device: " + err));
+            } else {
+                assert.equal(response.deviceId, deviceId, 'incorrect device id')
+                assert.equal(response.name, deviceName, 'incorrect device name')
+                done();
+            }
+        })
+    })
+
+    it('Shall activate device without token', function(done) {
+        assert.notEqual(deviceId, null, "Invalid device id")
+
+        helpers.devices.activateDeviceWithoutToken(activationCode, deviceId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot activate device: " + err));
+            } else {
+                deviceToken = response.deviceToken;
+                done();
+            }
+        });
+    }).timeout(5000);
+
+    it('Shall add device a component', function(done) {
+
+        helpers.devices.addDeviceComponent(componentName, componentType, userToken, accountId, deviceId, function(err, id) {
+            if (err) {
+                done(new Error("Cannot create component  " +  componentName + " : " +err));
+            } else {
+                if ( id ) {
+                    componentId = id;
+                    done()
+                }
+                else {
+                    done(new Error("Wrong id for component  " +  componentName ));
+                }
+            }
+        })
+
+
+    }).timeout(10000);
+
+    it('Shall send data point', function(done) {
+
+        helpers.devices.submitData("22", deviceToken, accountId, deviceId, componentId, function(err, response) {
+            if (err) {
+                done(new Error("Cannot create device: " + err));
+            } else {
+                done();
+            }
+        })
+    }).timeout(10000);
+})


### PR DESCRIPTION
* Creates a zip containing the relevant files
* Adds date to filename of zip and stores in ./backup
* create backup: "make backup"
* restore backup: "make restore" for the most recent backup or use var BACKUPFILE to specify specific backup
* Documentation for read-the-docs added
* Tests available, not yet part of main test.
* Test is triggered with make test-backup
* Updates db password according to configmap
* restart of frontend and keylcoak needed as described in documentation, for grafana, the whole deployment needs to be removed and redeployed

Signed-off-by: Marcel Wagner <wagmarcel@web.de>