### PR TITLE
Fix wait-until-ready.sh to use the right namespace of beam services.

### DIFF
--- a/wait-until-ready.sh
+++ b/wait-until-ready.sh
@@ -66,7 +66,7 @@ function check_beamservice {
   local counts_max=$3
   local counts_actual=0
   printf "\nWaiting for $name"
-  until (kubectl -n oisp get bs rule-engine -o yaml | grep "state: RUNNING");
+  until (kubectl -n $namespace get bs rule-engine -o yaml | grep "state: RUNNING");
     do printf "."
     let counts_actual=$counts_actual+1;
     if [ $counts_actual -ge $counts_max ];


### PR DESCRIPTION
Signed-off-by: Ali Rasim Kocal <arkocal@posteo.net>