### PR TITLE
moved retesting decision out of Makefile into circleci script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,11 +153,16 @@ commands:
             docker cp re-tmp:/rule-engine-bundled-0.1.jar .
             npm install nodemailer
             export NODOCKERLOGIN=true
-            make deploy-oisp-test DOCKER_TAG=test HELM_ARGS="--set ruleEngine.url=http://debugger/rule-engine-bundled-0.1.jar"
-            export DEBUGGER_POD=$(kubectl -n oisp get pods -o custom-columns=:metadata.name | grep debugger | head -n 1) &&
-            kubectl -n oisp cp rule-engine-bundled-0.1.jar ${DEBUGGER_POD}:/var/www/html &&
-            kubectl -n oisp exec ${DEBUGGER_POD} -- service nginx start
-            make test
+            retval=2;
+            until [ ${retval} -eq 0 ]; do
+              make undeploy-oisp
+              make deploy-oisp-test DOCKER_TAG=test HELM_ARGS="--set ruleEngine.url=http://debugger/rule-engine-bundled-0.1.jar"
+              export DEBUGGER_POD=$(kubectl -n oisp get pods -o custom-columns=:metadata.name | grep debugger | head -n 1) &&
+              kubectl -n oisp cp rule-engine-bundled-0.1.jar ${DEBUGGER_POD}:/var/www/html &&
+              kubectl -n oisp exec ${DEBUGGER_POD} -- service nginx start
+              make test
+              retval=$?
+            done
           no_output_timeout: 20m
   push-jar-over-ftp:
     description: "Push rule engine to FTP server"

--- a/Makefile
+++ b/Makefile
@@ -222,14 +222,12 @@ wait-until-ready:
 	if [ "$${DOCKER_TAG}" = "latest" ]; then \
 	  export DOCKER_TAG=test; \
 	fi; \
-	while ! $(SHELL) ./wait-until-ready.sh $(NAMESPACE); \
-		do \
-			if [ ! -z "${TEST}" ]; then \
-				printf "\nTimeout! Redeploying with docker tag $${DOCKER_TAG}\n"; \
-				make undeploy-oisp; \
-				make DOCKER_TAG=$${DOCKER_TAG} deploy-oisp-test; \
-			fi \
-		done }
+	$(SHELL) ./wait-until-ready.sh $(NAMESPACE); \
+	retval=$$?; \
+	if [ $${retval} -eq 2 ]; then \
+		printf "\nTimeout while waiting for platform\n"; \
+		exit 2; \
+	fi }
 
 ## import-images: Import images listed in CONTAINERS into local cluster
 ##

--- a/wait-until-ready.sh
+++ b/wait-until-ready.sh
@@ -98,6 +98,5 @@ check_deployment websocket-server ${NAMESPACE} mqtt-server 60
 check_job dbsetup ${NAMESPACE} 60
 check_sts keycloak ${NAMESPACE} 60
 check_beamservice rule-engine ${NAMESPACE} 120
-
 printf "\ndone\n"
 exit 0;


### PR DESCRIPTION
* Makefile is now exiting with "exit 2" if wait-until-ready.sh is exiting with 2
* Circleci e2e test will create a loop until the result of Makefile is 0

Signed-off-by: Marcel Wagner <wagmarcel@web.de>