### PR TITLE
Updated K3s and Cassandra Operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ export TEST = 0
 
 COMPOSE_PROJECT_NAME?="oisp"
 CONTAINERS?=$(shell docker-compose --log-level ERROR config --services)
-EXT_CONTAINERS=cassandra;gcr.io/cassandra-operator/cassandra-3.11.5:latest sidecar;gcr.io/cassandra-operator/cassandra-sidecar:latest kafka;confluentinc/cp-kafka:5.0.1
+EXT_CONTAINERS=cassandra;gcr.io/cassandra-operator/cassandra-3.11.6:latest sidecar;gcr.io/cassandra-operator/cassandra-sidecar:latest kafka;confluentinc/cp-kafka:5.0.1
 CONTAINERS_AGENT=oisp-testsensor oisp-iot-agent
 DOCKER_COMPOSE_ARGS?=
-K3S_NODE=$(shell docker ps --format '{{.Names}}' | grep k3s_node)
+K3S_NODE=$(shell docker ps --format '{{.Names}}' | grep k3s_agent)
 KEYCLOAK_HELM_REPO:="https://codecentric.github.io/helm-charts"
 KEYCLOAK_HELM_REPO_NAME:="codecentric"
 export DOCKER_TAG?=latest

--- a/kubernetes/templates/configmaps/cassandra-config.yaml
+++ b/kubernetes/templates/configmaps/cassandra-config.yaml
@@ -9,8 +9,8 @@ data:
   {{ else }}
   nodes: {{ .Values.cassandra.nodes | quote}}
   {{ end }}
-  cassandraImage: gcr.io/cassandra-operator/cassandra-3.11.5:latest
-  sidecarImage: gcr.io/cassandra-operator/cassandra-sidecar:latest
+  cassandraImage: gcr.io/cassandra-operator/cassandra-3.11.6:latest
+  sidecarImage: gcr.io/cassandra-operator/instaclustr-icarus:latest
   {{ if .Values.less_resources }}
   memory: 0.5Gi
   {{ else }}

--- a/util/deploy_operators.sh
+++ b/util/deploy_operators.sh
@@ -10,9 +10,13 @@ kubectl create -f https://github.com/minio/minio-operator/blob/1.0.7/minio-opera
 # Cassandra operator does not have helm chart yet
 helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
 kubectl create ns cassandra
-kubectl -n cassandra apply -f https://raw.githubusercontent.com/instaclustr/cassandra-operator/v3.1.1/deploy/crds.yaml
-kubectl -n cassandra apply -f https://raw.githubusercontent.com/instaclustr/cassandra-operator/v3.1.1/deploy/bundle.yaml
-kubectl -n cassandra delete cm cassandra-operator-default-config && \
+kubectl -n cassandra apply -f https://raw.githubusercontent.com/instaclustr/cassandra-operator/v6.7.0/deploy/crds.yaml
+# this is UGLY - but the operator is provided with latest tag even though a specific version is downloaded from github
+# In order to keep reproducability a specific tag for the operator is used
+curl https://raw.githubusercontent.com/instaclustr/cassandra-operator/v6.7.0/deploy/bundle.yaml \
+  | sed 's/image: "gcr.io\/cassandra-operator\/cassandra-operator:latest"/image: gcr.io\/cassandra-operator\/cassandra-operator:v6.7.0/g' \
+  | kubectl -n cassandra apply -f -
+kubectl -n cassandra delete cm cassandra-operator-default-config
 
 printf "\n"
 printf "\033[1mInstalling cert-manager\n"

--- a/util/restart-cluster.sh
+++ b/util/restart-cluster.sh
@@ -3,9 +3,15 @@ printf -- "------------\033[0m\n"
 pushd .
 rm -rf ~/k3s
 mkdir ~/k3s
-curl https://raw.githubusercontent.com/rancher/k3s/release/v1.0/docker-compose.yml > ~/k3s/docker-compose.yml
+# The server needs to run with --disable-agent, otherwise the containers will be distributed abount agent and server node.
+# Then we'd need to copy the images to both nodes which takes more time with no benefit (because it all runs on a single node anyhow)
+curl https://raw.githubusercontent.com/rancher/k3s/v1.17.13%2Bk3s1/docker-compose.yml | \
+  sed 's/command: server/command: server --disable-agent/g' \
+  > ~/k3s/docker-compose.yml
 #Compose down is necessary for subsequent runs to succeed
-cd ~/k3s && sudo docker-compose down -v && sudo docker-compose up -d
+export K3S_VERSION=v1.17.13-rc1-k3s1
+export K3S_TOKEN="abcdefghijgklm123456789"
+cd ~/k3s && sudo -E docker-compose down -v && sudo -E docker-compose up -d
 printf "Waiting for k3s to create kubeconfig file\n"
 while [ ! -f ~/k3s/kubeconfig.yaml ]
 do


### PR DESCRIPTION
* K3s now on v1.17.13
* Adapted K3s docker-compose to make sure that only the agent node is used for running containers
* Cassandra Operator now on v6.7.0
* Cassandra now on 3.11.6

Signed-off-by: Marcel Wagner <wagmarcel@web.de>