### PR TITLE
CircleCI config.yaml: Avoid 10min timeout from circleci while waiting…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ commands:
             retval=2;
             until [ ${retval} -eq 0 ]; do
               make undeploy-oisp
-              make deploy-oisp-test DOCKER_TAG=test
+              (for i in {1..20}; do sleep 60; echo .; done&) &&  make deploy-oisp-test DOCKER_TAG=test
               make test
               retval=$?
             done


### PR DESCRIPTION
… for helm deployment by regular output on stdout.

Signed-off-by: Marcel Wagner <wagmarcel@web.de>