### PR TITLE
Keycloak update: Due to dependency issues, the 8.0.1 listerner plugin…

### DIFF
--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -1,8 +1,8 @@
 ARG KEYCLOAK_VERSION="8.0.1"
 
-FROM maven:3.6.1-jdk-8-alpine AS keycloak-modules-builder
+FROM maven:3.6.3-jdk-8-slim AS keycloak-modules-builder
 
-RUN apk update && apk add build-base
+RUN apt -y -qq update && apt -y -qq install build-essential
 
 RUN mkdir /deployments
 

--- a/docker/keycloak/oisp-event-listener/pom.xml
+++ b/docker/keycloak/oisp-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>8.0.1</version>
+        <version>9.0.0</version>
     </parent>
 
     <name>Oisp Event Listener</name>


### PR DESCRIPTION
… cannot be compiled. Instead the plugin version is increased to 9.0.0 but the main keycloak version stays the same

Signed-off-by: Marcel Wagner <wagmarcel@web.de>