### PR TITLE
Upgrade stolon image to 0.16 from 0.12 for k8s 1.18 compat

### DIFF
--- a/kubernetes/charts/stolon/values.yaml
+++ b/kubernetes/charts/stolon/values.yaml
@@ -14,7 +14,7 @@ image: "sorintlab/stolon"
 ## Stolon image version.
 ## ref: https://hub.docker.com/r/sorintlab/stolon/tags/
 ##
-imageTag: "v0.12.0-pg10"
+imageTag: "v0.16.0-pg10"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
This is a temporary fix, as the stolon chart is no longer maintained,
and the version we are using is very old.

Signed-off-by: Ali Rasim Kocal <arkocal@posteo.net>