### PR TITLE
CI: Fix push-images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,3 @@
-# Javascript Node CircleCI 2.0 configuration file
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2.1
 executors:
   my-executor:
@@ -160,8 +157,6 @@ commands:
           command: |
             export PATH=$PATH:/snap/bin
             make import-images DOCKER_TAG=test DEBUG=true
-            docker create -it --name re-tmp oisp/rule-engine:test /bin/sh
-            docker cp re-tmp:/rule-engine-bundled-0.1.jar .
             npm install nodemailer
             export NODOCKERLOGIN=true
             retval=2;
@@ -172,24 +167,6 @@ commands:
               retval=$?
             done
           no_output_timeout: 20m
-  push-jar-over-ftp:
-    description: "Push rule engine to FTP server"
-    steps:
-      - run:
-          shell: /bin/bash
-          name: Push jar to ftp server
-          command: |
-            HOST='82.165.114.145'
-            USER='ftp'
-            PASSWD=${FTPPASS}
-            ftp -n -v $HOST \<< EOT
-            user $USER $PASSWD
-            prompt
-            pass
-            cd files
-            put rule-engine-bundled-0.1.jar
-            bye
-            EOT
   push-images:
     description: "Push images"
     parameters:
@@ -320,7 +297,6 @@ jobs:
       - e2e-test
       - push-images:
           tag: "date"
-      - push-jar-over-ftp
   deploy-production:
     executor: deployer
     steps:

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,7 @@ import-images:
 		printf $(image) && \
 		docker tag $(DOCKER_PREFIX)/$(image):$(DOCKER_TAG) k3d-oisp.localhost:12345/$(DOCKER_PREFIX)/$(image):$(DOCKER_TAG) && \
 		docker push k3d-oisp.localhost:12345/$(DOCKER_PREFIX)/$(image):$(DOCKER_TAG) && \
+		docker rmi k3d-oisp.localhost:12345/$(DOCKER_PREFIX)/$(image):$(DOCKER_TAG) && \
 		printf ", imported\n" \
 	)
 
@@ -270,6 +271,7 @@ import-images:
 		docker pull $${arr[1]} > /dev/null && printf ", pulled" && \
 		docker tag $${arr[1]} k3d-oisp.localhost:12345/$${arr[1]} && \
 		docker push k3d-oisp.localhost:12345/$${arr[1]} && \
+		docker rmi k3d-oisp.localhost:12345/$${arr[1]} && \
 		printf ", saved\n"; \
 	)
 

--- a/ci_deployer/deploy.sh
+++ b/ci_deployer/deploy.sh
@@ -6,11 +6,5 @@ echo y | make update
 export DOCKERUSER=${DOCKER_USERNAME}
 export DOCKERPASS=${DOCKER_PASSWORD}
 export NODOCKERLOGIN=true
-if [[ $(helm ls -q --all-namespaces | grep "${NAME}\$") ]]; then
-    CMD="upgrade"
-    rm kubernetes/templates/jobs/db_setup.yaml
-else
-    CMD="deploy"
-fi;
 export DOCKER_PREFIX=oisp
-make ${CMD}-oisp DOCKER_TAG=nightly-$(date +"%Y-%m-%d") NOBACKUP=true
+(while true; do sleep 60 && echo "This message prevents CI timeout"; done) & (make upgrade-oisp DOCKER_TAG=nightly-$(date +"%Y-%m-%d") NOBACKUP=true)


### PR DESCRIPTION
import-images created local images that should not be pushed. These are removed.
Also removed legacy functions from CI

Signed-off-by: Ali Rasim Kocal <arkocal@posteo.net>