### PR TITLE
CI: Fix false trigger for tagged builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,8 +347,7 @@ workflows:
       - build-tagged:
           filters:
             branches:
-              only:
-                - develop
+              ignore: /.*/
             tags:
               only: /^v.*/
   nightly:


### PR DESCRIPTION
CircleCI filters are ORed, so branch filter for develop should be removed.

Signed-off-by: Ali Rasim Kocal <arkocal@posteo.net>