### PR TITLE
Update Flink to v1.13 and introduction beamsqlstatementsets CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ upgrade-oisp: check-docker-cred-env backup
 undeploy-oisp:
 	@cd kubernetes && \
 	(kubectl delete -n $(NAMESPACE) bs --all || echo "Beam services not (or already) deleted") && \
+	(kubectl delete -n $(NAMESPACE) bsqls --all || echo "Beam SQL services not (or already) deleted") && \
 	( helm uninstall $(NAME) --namespace $(NAMESPACE) || echo helm uninstall failed)  && \
 	(kubectl delete namespace $(NAMESPACE) || echo "namespace not (or already) deleted") && \
 	(kubectl -n cassandra delete cassandradatacenter $(NAMESPACE) || echo "cassandra dc not (or already) deleted")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,3 +96,9 @@ services:
       context: ./docker/wait-for-it/
       labels:
         - oisp=true
+  simple-flink-sql-gateway:
+    image: ${DOCKER_PREFIX:-oisp}/simple-flink-sql-gateway:${DOCKER_TAG}
+    build:
+      context: ./oisp-services/simple-flink-sql-gateway
+      labels:
+        - oisp=true

--- a/kubernetes/templates/component-splitter.yaml
+++ b/kubernetes/templates/component-splitter.yaml
@@ -9,4 +9,4 @@ spec:
     streaming: "true"
 
   package:
-    url: "http://services-server/component-splitter-bundled-0.1.1.jar"
+    url: "http://services-server/component-splitter-bundled-0.1.2.jar"

--- a/kubernetes/templates/flink/flink-configuration-configmap.yaml
+++ b/kubernetes/templates/flink/flink-configuration-configmap.yaml
@@ -15,8 +15,9 @@ data:
     blob.server.port: 6124
     jobmanager.rpc.port: 6123
     taskmanager.rpc.port: 6122
-    jobmanager.heap.size: 1024m
+    jobmanager.memory.process.size: 1024m
     taskmanager.memory.process.size: 1024m
+    taskmanager.memory.managed.size: 0m
     restart-strategy: fixed-delay
     restart-strategy.fixed-delay.attempts: 30
     restart-strategy.fixed-delay.delay: 10 s
@@ -29,13 +30,42 @@ data:
     s3.secret-key: {{ .Values.minio.secretkey }}
 
   log4j.properties: |+
-    log4j.rootLogger=INFO, file
-    log4j.logger.akka=INFO
-    log4j.logger.org.apache.kafka=INFO
-    log4j.logger.org.apache.hadoop=INFO
-    log4j.logger.org.apache.zookeeper=INFO
-    log4j.appender.file=org.apache.log4j.FileAppender
-    log4j.appender.file.file=${log.file}
-    log4j.appender.file.layout=org.apache.log4j.PatternLayout
-    log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
-    log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file
+    monitorInterval=30
+    # This affects logging for both user code and Flink
+    rootLogger.level = INFO
+    rootLogger.appenderRef.file.ref = MainAppender
+
+    # Uncomment this if you want to _only_ change Flink's logging
+    #logger.flink.name = org.apache.flink
+    #logger.flink.level = INFO
+
+    # The following lines keep the log level of common libraries/connectors on
+    # log level INFO. The root logger does not override this. You have to manually
+    # change the log levels here.
+    logger.akka.name = akka
+    logger.akka.level = INFO
+    logger.kafka.name= org.apache.kafka
+    logger.kafka.level = INFO
+    logger.hadoop.name = org.apache.hadoop
+    logger.hadoop.level = INFO
+    logger.zookeeper.name = org.apache.zookeeper
+    logger.zookeeper.level = INFO
+
+    # Log all infos in the given file
+    appender.main.name = MainAppender
+    appender.main.type = Console
+    appender.main.append = true
+    #appender.main.fileName = ${sys:log.file}
+    #appender.main.filePattern = ${sys:log.file}.%i
+    appender.main.layout.type = PatternLayout
+    appender.main.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+    appender.main.policies.type = Policies
+    #appender.main.policies.size.type = SizeBasedTriggeringPolicy
+    #appender.main.policies.size.size = 100MB
+    #appender.main.policies.startup.type = OnStartupTriggeringPolicy
+    appender.main.strategy.type = DefaultRolloverStrategy
+    #appender.main.strategy.max = ${env:MAX_LOG_FILE_NUMBER:-10}
+
+    # Suppress the irrelevant (wrong) warnings from the Netty channel handler
+    logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+    logger.netty.level = OFF

--- a/kubernetes/templates/flink/jobmanager-deployment.yaml
+++ b/kubernetes/templates/flink/jobmanager-deployment.yaml
@@ -23,17 +23,12 @@ spec:
         command: ["/bin/bash", "-c", "mc mb -p oisp/{{ .Values.flink.checkpoints.bucket }}"]
       containers:
       - name: jobmanager
-        image: flink:1.10.2
+        image: flink:{{ .Values.flink.version }}
         workingDir: /opt/flink
         command: ["/bin/bash", "-c", "mkdir -p /opt/flink/plugins/s3; \
           cp /opt/flink/opt/flink-s3-fs-hadoop-*.jar /opt/flink/plugins/s3 ; \
-          $FLINK_HOME/bin/jobmanager.sh start;\
-          while :;
-          do
-            if [[ -f $(find log -name '*jobmanager*.log' -print -quit) ]];
-              then tail -f -n +1 log/*jobmanager*.log;
-            fi;
-          done"]
+          $FLINK_HOME/bin/jobmanager.sh start-foreground; \
+          "]
         ports:
         - containerPort: 6123
           name: rpc
@@ -51,6 +46,33 @@ spec:
           mountPath: /opt/flink/conf
         securityContext:
           runAsUser: 9999  # refers to user _flink_ from official flink image, change if necessary
+      - name: sql-gateway
+         {{ if .Values.use_local_registry }}
+        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/simple-flink-sql-gateway:{{ .Values.tag }}
+        {{ else }}
+        image: {{ .Values.imagePrefix }}/simple-flink-sql-gateway:{{ .Values.tag }}
+        {{ end }}
+        workingDir: /opt/gateway
+        command: ["/bin/bash", "-c", "nodejs gateway.js"]
+        env:
+        - name: SIMPLE_FLINK_SQL_GATEWAY_PORT
+          value: {{ .Values.flink.sqlClientPort | quote }}
+        - name: DEBUG
+          value: express:*
+        ports:
+        - containerPort: {{ .Values.flink.sqlClientPort }}
+          name: rest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.flink.sqlClientPort }}
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        #volumeMounts:
+        #- name: flink-config-volume
+        #  mountPath: /opt/flink/conf
+        securityContext:
+          runAsUser: 9999  # refers to user _flink_ from official flink image, change if necessary
       volumes:
       - name: flink-config-volume
         configMap:
@@ -59,4 +81,4 @@ spec:
           - key: flink-conf.yaml
             path: flink-conf.yaml
           - key: log4j.properties
-            path: log4j.properties
+            path: log4j-console.properties

--- a/kubernetes/templates/flink/jobmanager-rest-service.yaml
+++ b/kubernetes/templates/flink/jobmanager-rest-service.yaml
@@ -11,3 +11,17 @@ spec:
   selector:
     app: flink
     component: jobmanager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flink-sql-gateway
+spec:
+  type: ClusterIP
+  ports:
+  - name: rest
+    port: {{ .Values.flink.sqlClientPort }}
+    targetPort: {{ .Values.flink.sqlClientPort }}
+  selector:
+    app: flink
+    component: jobmanager

--- a/kubernetes/templates/flink/taskmanager-deployment.yaml
+++ b/kubernetes/templates/flink/taskmanager-deployment.yaml
@@ -20,17 +20,12 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:1.10.2
+        image: flink:{{ .Values.flink.version }}
         workingDir: /opt/flink
         command: ["/bin/bash", "-c", "mkdir -p /opt/flink/plugins/s3; \
           cp /opt/flink/opt/flink-s3-fs-hadoop-*.jar /opt/flink/plugins/s3; \
-          $FLINK_HOME/bin/taskmanager.sh start; \
-          while :;
-          do
-            if [[ -f $(find log -name '*taskmanager*.log' -print -quit) ]];
-              then tail -f -n +1 log/*taskmanager*.log;
-            fi;
-          done"]
+          $FLINK_HOME/bin/taskmanager.sh start-foreground;\
+          "]
         resources:
           {{ if .Values.less_resources }}
           requests:
@@ -52,6 +47,8 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 60
         volumeMounts:
+        - mountPath: /dump
+          name: cache-volume
         - name: flink-config-volume
           mountPath: /opt/flink/conf/
         securityContext:
@@ -64,4 +61,6 @@ spec:
           - key: flink-conf.yaml
             path: flink-conf.yaml
           - key: log4j.properties
-            path: log4j.properties
+            path: log4j-console.properties
+      - name: cache-volume
+        emptyDir: {}

--- a/kubernetes/templates/metrics-aggregator.yaml
+++ b/kubernetes/templates/metrics-aggregator.yaml
@@ -1,16 +1,176 @@
-apiVersion: oisp.org/v1
-kind: BeamService
+apiVersion: oisp.org/v1alpha1
+kind: BeamSqlTable
+metadata:
+  name: metrics
+spec:
+  connector: kafka
+  fields:
+    'aid': STRING
+    'value': STRING
+    'dvalue': AS CAST(`value` AS DOUBLE)
+    'on': BIGINT
+    'ts': AS epoch2SQL(`on`, 'Europe/Berlin')
+    'cid': STRING
+    'systemon': BIGINT
+    'dataType': STRING
+    'watermark': FOR `ts` AS `ts` - INTERVAL '5' SECOND
+  kafka:
+    topic: metrics
+    properties:
+      bootstrap.servers: oisp-kafka-headless:9092
+      fetch.message.max.bytes: 15728640
+    scan.startup.mode: latest-offset
+  value:
+    format: json
+    json.fail-on-missing-field: false
+    json.ignore-parse-errors: true
+---
+apiVersion: oisp.org/v1alpha1
+kind: BeamSqlTable
+metadata:
+  name: metrics-sink
+spec:
+  connector: kafka
+  fields:
+    'aid': STRING
+    'value': STRING
+    'on': BIGINT
+    'cid': STRING
+    'systemon': BIGINT
+    'dataType': STRING
+  kafka:
+    topic: metrics
+    properties:
+      bootstrap.servers: oisp-kafka-headless:9092
+      fetch.message.max.bytes: 15728640
+    scan.startup.mode: latest-offset
+  value:
+    format: json
+    json.fail-on-missing-field: false
+    json.ignore-parse-errors: true
+---
+apiVersion: oisp.org/v1alpha1
+kind: BeamSqlStatementSet
 metadata:
   name: metrics-aggregator
 spec:
-  entryClass: "org.oisp.services.MetricsAggregator"
-  args:
-    runner: FlinkRunner
-    streaming: "true"
-    {{ if .Values.production }}
-    checkpointingInterval: {{ .Values.metricsAggregator.checkpointingInterval | quote }}
-    {{ end }}
-    metricsTopic: {{ .Values.metricsAggregator.metricsTopic | quote }}
-    bootstrapServers: {{ .Values.kafka.service}}
-  package:
-    url: {{ .Values.metricsAggregator.url }}
+  sqlstatements:
+    - |
+      insert into `metrics-sink`
+      with aggregation as
+      (select
+        TUMBLE_START(ts, INTERVAL '60' MINUTE) as `window-start`,
+        AVG(`dvalue`) as average, SUM(`dvalue`) as `sum`,
+        MIN(`dvalue`) as `min`, MAX(`dvalue`) as `max`,
+        COUNT(`on`) as `count`,
+        dataType,
+        cid,
+        aid
+        from metrics
+        where regexp_extract(cid, '^([^\.]*)$',1) is not null and `dataType`='Number'
+        group by TUMBLE(ts, INTERVAL '60' MINUTE), cid, aid, dataType)
+      select
+        aid,
+        concat(cid, '.aggregator.AVG.hours') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(average as String) as `value`
+        from aggregation
+      union all
+      select
+        aid,
+        concat(cid, '.aggregator.COUNT.hours') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`count` as String) as `value`
+        from aggregation
+      union all
+      select
+        aid,
+        concat(cid, '.aggregator.MAX.hours') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`max` as String) as `value`
+        from aggregation
+      union all
+      select
+        aid,
+        concat(cid, '.aggregator.MIN.hours') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`min` as String) as `value`
+        from aggregation
+        union all
+      select
+        aid,
+        concat(cid, '.aggregator.SUM.hours') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`sum` as String) as `value`
+        from aggregation;
+    - |
+      insert into `metrics-sink`
+      with aggregation as
+      (select
+        TUMBLE_START(ts, INTERVAL '60' SECOND) as `window-start`,
+        AVG(`dvalue`) as average, SUM(`dvalue`) as `sum`,
+        MIN(`dvalue`) as `min`, MAX(`dvalue`) as `max`,
+        COUNT(`on`) as `count`,
+        dataType,
+        cid,
+        aid
+        from metrics
+        where regexp_extract(cid, '^([^\.]*)$',1) is not null and `dataType`='Number'
+        group by TUMBLE(ts, INTERVAL '60' SECOND), cid, aid, dataType)
+      select
+        aid,
+        concat(cid, '.aggregator.AVG.minutes') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(average as String) as `value`
+        from aggregation
+      union all
+      select
+        aid,
+        concat(cid, '.aggregator.COUNT.minutes') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`count` as String) as `value`
+        from aggregation
+      union all
+      select
+        aid,
+        concat(cid, '.aggregator.MAX.minutes') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`max` as String) as `value`
+        from aggregation
+      union all
+      select
+        aid,
+        concat(cid, '.aggregator.MIN.minutes') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`min` as String) as `value`
+        from aggregation
+        union all
+      select
+        aid,
+        concat(cid, '.aggregator.SUM.minutes') as cid,
+        dataType,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `on`,
+        (unix_timestamp(cast (`window-start` as string)) + 30) * 1000 as `systemOn`,
+        cast(`sum` as String) as `value`
+        from aggregation;
+  tables:
+    - metrics
+    - metrics-sink

--- a/kubernetes/templates/services-operator.yaml
+++ b/kubernetes/templates/services-operator.yaml
@@ -20,7 +20,7 @@ spec:
       {{ end }}
         name: services-operator
         command: ["kopf"]
-        args: ["run", "--log-format", "plain", "--standalone", "/opt/beamservicesoperator.py"]
+        args: ["run", "--log-format", "plain", "--standalone", "-A", "/opt/beamservicesoperator.py", "/opt/beamsqlstatementsetoperator.py"]
         volumeMounts:
         - mountPath: /tmp
           name: beamservices-operator-data

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -189,12 +189,7 @@ mqtt:
 ruleEngine:
   username: "rule_engine@intel.com"
   password: password
-  url: "http://services-server/rule-engine-bundled-0.1.1.jar"
-  checkpointingInterval : "10000"
-
-metricsAggregator:
-  metricsTopic: "metrics"
-  url: "http://services-server/metrics-aggregator-bundled-0.1.1.jar"
+  url: "http://services-server/rule-engine-bundled-0.1.2.jar"
   checkpointingInterval : "10000"
 
 websocketServer:
@@ -324,6 +319,8 @@ less_resources: true
 production: false
 
 flink:
+  version: 1.13.0
+  sqlClientPort: 9000
   restPort: 8081
   restUrl: flink-jobmanager-rest
   url: flink-jobmanager

--- a/util/deploy_operators.sh
+++ b/util/deploy_operators.sh
@@ -20,7 +20,7 @@ curl https://raw.githubusercontent.com/instaclustr/cassandra-operator/v6.7.0/dep
 kubectl -n cassandra delete cm cassandra-operator-default-config
 
 ## install CRDs for services operator - operator will be installed later by helm
-kubectl apply -f https://raw.githubusercontent.com/Open-IoT-Service-Platform/oisp-services/b23f55fedb345c2f6e719c29801ffd98cf6e54db/services-operator/kubernetes/crd.yml
+kubectl apply -f https://raw.githubusercontent.com/wagmarcel/oisp-services/flink-1-13-streaming-sql-v2/services-operator/kubernetes/crd.yml
 
 printf "\n"
 printf "\033[1mInstalling cert-manager\n"


### PR DESCRIPTION
Updates from this PR:
- Update from Flink 1.10 to 1.13
-- Flink 1.13 pod now contains a sidecar with the sqlgateway
- Introduce 2 new CRDs: beamsqlstatementsets and beamsqltables
-- In order to enabe new CRD, the CRDs from this PR branch needs to be referenced - needs to be removed in future commits
- Old beamservice metricsaggregator has been removed and replaced by a new beamsqlstatementscript executing the same task
- Makefile now deletes beamsqlstatementsets while undeploying
- Rule-engine and component splitter beamservices are updated to be compatible with Flink 1.13

Issues:
closing #449

Signed-off-by: Marcel Wagner <wagmarcel@web.de>