### PR TITLE
Migration script: Fixed a sanity check

### DIFF
--- a/kubernetes/templates/postgres.yaml
+++ b/kubernetes/templates/postgres.yaml
@@ -14,7 +14,7 @@ spec:
     superuser:  # database owner
     - superuser
     - createdb
-    oispuser: []  # role for application foo
+#    oispuser: []  # role for application foo
 #  databases:
 #    foo: superuser  # dbname: owner
 #  preparedDatabases:

--- a/util/migrations/stolon-to-zalando.sh
+++ b/util/migrations/stolon-to-zalando.sh
@@ -9,7 +9,7 @@ ZALANDO_PODNAME="acid-oisp-0"
 ZALANDO_SERVICE="acid-oisp"
 ZALANDO_DBNAME="oisp"
 
-ZALANDO_OISP_USER="oispuser"
+ZALANDO_OISP_USER="oisp_user"
 NAMESPACE="${NAMESPACE:-oisp}"
 
 TMPDIR="/tmp/stolon-zalando-migration/"
@@ -30,6 +30,6 @@ echo "Database oisp exists, ready for migration"
      make restore-db) || (echo "DB restoration failed" && exit 1)
 
 echo "Found following users and maybe more (sanity check:)"
-kubectl -n ${NAMESPACE} exec ${ZALANDO_PODNAME} -- psql -d oisp -U oispuser -c "SELECT email FROM dashboard.users;" | tail
+kubectl -n ${NAMESPACE} exec ${ZALANDO_PODNAME} -- psql -d oisp -U oisp_user -c "SELECT email FROM dashboard.users;" | tail
 
 echo "Data migration successful, configuration can be updated to use Zalando from now on."


### PR DESCRIPTION

Closes #522 

The sanity check in question: ```kubectl -n ${NAMESPACE} exec ${ZALANDO_PODNAME} -- psql -d oisp -U oispuser -c "SELECT email FROM dashboard.users;" | tail``` works as intended after the change from "oispuser" to "oisp_user" 

```kubectl -n oisp exec acid-oisp-0 -- psql -d oisp -U oisp_user -c "SELECT email FROM dashboard.users;" | tail ``` giving the intended output of: 
```
            email
-----------------------------
 placeholder@placeholder.org
 gateway@intel.com
 rule_engine@intel.com
(3 rows)
```
After the change, "oispuser" field in the Zalando config file, postgres.yaml is unneeded, thus it's commented out.

Signed-off-by: Meric <meric.feyzullahoglu@gmail.com>
