### PR TITLE
CI: Added oisp upgrade from current to latest test...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,10 @@ commands:
             yes| make build DOCKER_TAG="test" DEBUG=true
   e2e-test:
     description: "E2E test"
+    parameters:
+      upgrade-test:
+        type: string
+        default: "false"
     steps:
       - run:
           shell: /bin/bash
@@ -166,9 +170,22 @@ commands:
             npm install nodemailer
             export NODOCKERLOGIN=true
             retval=2;
+            export DOCKER_TAG=test
+            export USE_LOCAL_REGISTRY=true
+            # If CURRENT_RELEASE_VERSION is set, do an upgrade test from the release version to latest
+            if [[ "<< parameters.upgrade-test >>" = "true" ]] && [[ -n "${CURRENT_RELEASE_VERSION}" ]];
+            then
+              export DOCKER_TAG="${CURRENT_RELEASE_VERSION}"
+              export USE_LOCAL_REGISTRY=false
+            fi
             until [ ${retval} -eq 0 ]; do
               make undeploy-oisp
-              (for i in {1..20}; do sleep 60; echo .; done&) &&  make deploy-oisp-test DOCKER_TAG=test USE_LOCAL_REGISTRY=true
+              (for i in {1..20}; do sleep 60; echo .; done&) &&  make deploy-oisp-test
+              if [[ "<< parameters.upgrade-test >>" = "true" ]] && [[ -n "${CURRENT_RELEASE_VERSION}" ]];
+              then
+                (for i in {1..20}; do sleep 60; echo .; done&) &&  make upgrade-oisp DOCKER_TAG=test USE_LOCAL_REGISTRY=true KEYCLOAK_FORCE_MIGRATION="true"
+                kubectl -n $(NAMESPACE) scale deployment debugger --replicas=1
+              fi
               make test
               retval=$?
             done
@@ -300,7 +317,8 @@ jobs:
       - setup-branch
       - e2e-linter
       - build-branch
-      - e2e-test
+      - e2e-test:
+          upgrade-test: "true"
       - push-images:
           tag: "date"
   deploy-production:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ DOCKER_COMPOSE_ARGS?=
 K3S_NODE=$(shell docker ps --format '{{.Names}}' | grep k3s_agent)
 KEYCLOAK_HELM_REPO:="https://codecentric.github.io/helm-charts"
 KEYCLOAK_HELM_REPO_NAME:="codecentric"
+KEYCLOAK_FORCE_MIGRATION?=""
 export K3S_IMAGE?=rancher/k3s:v1.20.7-k3s1
 export DOCKER_TAG?=latest
 export DOCKER_PREFIX?=oisp
@@ -158,6 +159,7 @@ deploy-oisp: check-docker-cred-env
 		--set imagePrefix=$(DOCKER_PREFIX) \
 		--set keycloak.keycloak.image.repository=$${KEYCLOAK_REGISTRY}$(DOCKER_PREFIX)/keycloak \
 		--set keycloak.keycloak.image.tag=$(DOCKER_TAG) \
+		--set keycloak.forceMigration=$(KEYCLOAK_FORCE_MIGRATION) \
 		--set use_local_registry=$(USE_LOCAL_REGISTRY) \
 		$(HELM_ARGS)
 

--- a/kubernetes/templates/configmaps/oisp-config.yaml
+++ b/kubernetes/templates/configmaps/oisp-config.yaml
@@ -145,6 +145,7 @@ data:
   keycloak-frontend-secret: {{ .Values.keycloak.frontend.secret }}
   keycloak-websocket-server-secret: {{ .Values.keycloak.websocketServer.secret }}
   keycloak-mqtt-broker-secret: {{ .Values.keycloak.mqttBroker.secret }}
+  keycloak-force-migration: "{{ .Values.keycloak.forceMigration }}"
   gateway: |
     {
     "username": "{{ .Values.systemuser.username }}",

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -238,6 +238,11 @@ keycloak:
         value: "http://frontend:4004/keycloak/users/:userId"
       - name: PGSSLMODE
         value: require
+      - name: FORCE_MIGRATION
+        valueFrom:
+          configMapKeyRef:
+            name: oisp-config
+            key: keycloak-force-migration
       - name: OISP_FRONTEND_SECRET
         valueFrom:
           configMapKeyRef:
@@ -292,6 +297,7 @@ keycloak:
   # Example: URL of Frontend - https://latest.oisp.info:443
   #          Auth Server URL for Applications in Other Namespaces: https://latest.oisp.info:443/keycloak
   authServerUrl: "http://keycloak-http:4080/keycloak"
+  forceMigration: ""
 
 jwt:
   public: "No key set"


### PR DESCRIPTION
- If CURRENT_RELEASE_VERSION is set, tests upgrade from specified version to latest
- make upgrade-oisp command now takes optional KEYCLOAK_FORCE_MIGRATION(default: false) argument
- closes #461

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>