### PR TITLE
CI: Nightly Migration to Github Actions

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -1,6 +1,8 @@
 name: End2End Test
 
 on:
+  workflow_call:
+
   pull_request:
     branches:
       - develop
@@ -10,14 +12,13 @@ on:
       - '**-debugtest'
 jobs:
   build:
-
     runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.ref }}
-
+        submodules: recursive
     - name: Prepare platform
       shell: bash
       run: |
@@ -28,8 +29,7 @@ jobs:
       shell: bash
       run: |
         export TERM=vt100
-        sudo apt install jq
-        git submodule update --recursive --init
+        #git submodule update --recursive --init
         make update
 
     - name: Build platform
@@ -64,4 +64,3 @@ jobs:
     - name: debug with upterm
       if: failure()
       uses: lhotari/action-upterm@v1
-

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,96 @@
+
+
+name: Nigthly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  test:
+    uses: Open-IoT-Service-Platform/platform-launcher/.github/workflows/makefile.yaml@develop
+  build:
+    needs: test
+    runs-on: ubuntu-20.04
+    env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_PREFIX: ${{ secrets.DOCKER_PREFIX }}
+          PUSH_DRYRUN: ''
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          submodules: recursive
+      - name: Prepare Platform
+        shell: bash
+        run: |
+          export TERM=vt100
+          cd util && \
+          bash setup-ubuntu20.04.sh
+      - name: Setup and Build
+        shell: bash
+        run: |
+          export TERM=vt100
+          set +o pipefail
+          make update
+          yes | DOCKER_TAG=test NODOCKERLOGIN=true DEBUG=true make build
+      - name: Push images
+        shell: bash
+        run: |
+          export TERM=vt100
+          set +o pipefail
+          docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+          # Tag passed "test" images as "latest"
+          images=$(docker images --format "{{.Repository}}:{{.Tag}}"| grep :test)
+          for image in $images; do
+            newimage=$(echo $image | sed -r "s/:test/:latest/g" | sed -r "s/$DOCKER_PREFIX/oisp/g");
+            docker tag $image $newimage;
+          done
+          #Start with latest tag, replace later by the real-tags
+          DOCKER_TAG="latest"
+          TARGET_DOCKER_TAG=nightly-`date -I`
+          DOCKER_PUSH_LATEST=true
+          # First push latest if applicable and then the real tag
+          echo Now trying to push with Tag ${DOCKER_TAG} push latest ${DOCKER_PUSH_LATEST}
+          if [ "$DOCKER_PUSH_LATEST" = "true" ]; then
+            echo Pushing images with latest tag
+            if [ -z "$PUSH_DRYRUN" ]; then
+              make push-images DOCKER_PREFIX=oisp
+            else
+              echo Only dry run mode. Not pushing to dockerhub!
+            fi
+          fi
+          # Now replace all latest tagged images by the real tag
+          echo Now pushing images with tag $DOCKER_TAG
+          images=$(docker images --format "{{.Repository}}:{{.Tag}}"| grep :latest | grep "oisp/")
+          for image in $images; do
+            newimage=$(echo $image | sed -r "s/:latest/:$TARGET_DOCKER_TAG/g");
+            echo tagging $image to $newimage;
+            docker tag $image $newimage
+            if [ -z "$PUSH_DRYRUN" ]; then
+              docker push ${newimage}
+            else
+              echo Only dry run mode. Not pushing to dockerhub!
+            fi
+          done
+  docker-action:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: oisp/deployer:latest
+      credentials:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    steps:
+      - name: Deploy Test
+        run: |
+          export TERM=vt100
+          cd /home/deployer
+          export HELM_ARGS="--atomic \
+            --set less_resources=\"false\" --set production=\"true\" \
+            --set certmanager.secret=\"frontend-web-prod-tls\" \
+            --set certmanager.issuer=\"letsencrypt-prod\" \
+            --set numberReplicas.frontend=2 \
+            --set numberReplicas.backend=3"
+          sh deploy.sh


### PR DESCRIPTION
Workflow for releasing nightly builds, that triggers every night. It first tests the default branch by reusing the e2e test workflow, builds actual and pushes images to Dockerhub, and then updates the helm chart. 

E2E test workflow is now a reusable workflow. Jq install command is removed as it is present in setup script, and setting ```submodules``` parameter of ```actions/checkout``` to ```recursive``` lets us remove (comment it out in this case) the ```git submodule update``` line. 

Closes #553 

Signed-off-by: Meric <meric.feyzullahoglu@gmail.com>