### PR TITLE
Fix the deploy docker action for the nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -75,6 +75,10 @@ jobs:
           done
   docker-action:
     needs: build
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      NAMESPACE: ${{ secrets.NAMESPACE }}
     runs-on: ubuntu-latest
     container:
       image: oisp/deployer:latest
@@ -86,7 +90,9 @@ jobs:
       - name: Deploy Test
         run: |
           export TERM=vt100
+          export HOME=/home/deployer
           cd /home/deployer
+          export KUBECONFIG=/home/deployer/.kube/config
           export HELM_ARGS="--atomic \
             --set less_resources=\"false\" --set production=\"true\" \
             --set certmanager.secret=\"frontend-web-prod-tls\" \


### PR DESCRIPTION
Github Actions overrides the home and working directory parameters
of the Dockerfile, therefore we need to set them correctly for both
kubectl and helm, since they try to search the home directories for
their config files.

Since the namespace of the latest.oisp.info is different than the
default, we add the NAMESPACE secret.

Follow-up  to: #556

Signed-off-by: Meric <meric.feyzullahoglu@gmail.com>