### PR TITLE
Implement Nightly Upgrade Test

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -2,6 +2,17 @@ name: End2End Test
 
 on:
   workflow_call:
+    inputs:
+      UPGRADE_TEST:
+        description: 'Set to "true" to enable version upgrade testing before E2E testing'
+        default: ''
+        required: false
+        type: string
+      CURRENT_RELEASE_VERSION:
+        description: 'Release version to upgrade from, must be a valid docker tag'
+        default: ''
+        required: false
+        type: string
 
   pull_request:
     branches:
@@ -12,6 +23,9 @@ on:
       - '**-debugtest'
 jobs:
   build:
+    env:
+      UPGRADE_TEST: ''
+      CURRENT_RELEASE_VERSION: ''
     runs-on: ubuntu-20.04
 
     steps:
@@ -38,6 +52,12 @@ jobs:
         export TERM=vt100
         yes | DOCKER_TAG=test NODOCKERLOGIN=true DEBUG=true make build
 
+    - name: Set Env
+      if: ${{ inputs.UPGRADE_TEST == 'true' && inputs.CURRENT_RELEASE_VERSION != '' }}
+      run: |
+        set +o pipefail
+        echo "UPGRADE_TEST=${{ inputs.UPGRADE_TEST }}" >> $GITHUB_ENV
+        echo "CURRENT_RELEASE_VERSION=${{ inputs.CURRENT_RELEASE_VERSION }}" >> $GITHUB_ENV
     - name: E2E Test
       shell: bash
       run: |
@@ -52,9 +72,23 @@ jobs:
         retval=2;
         export DOCKER_TAG=test
         export USE_LOCAL_REGISTRY=true
+        # If CURRENT_RELEASE_VERSION is set, do an upgrade test from the release version to latest
+        if [[ ${UPGRADE_TEST} = "true" ]] && [[ -n ${CURRENT_RELEASE_VERSION} ]];
+        then
+          export DOCKERLOGIN=${{ secrets.DOCKER_USERNAME }}
+          export DOCKERPASS=${{ secrets.DOCKER_PASSWORD }}
+          export DOCKER_TAG=${CURRENT_RELEASE_VERSION}
+          export USE_LOCAL_REGISTRY=false
+        fi
         until [ ${retval} -eq 0 ] || [ ${loops} -gt 3 ]; do
           make undeploy-oisp
           (for i in {1..20}; do sleep 60; echo .; done&) &&  make deploy-oisp-test
+          if [[ ${UPGRADE_TEST} = "true" ]] && [[ -n ${CURRENT_RELEASE_VERSION} ]];
+          then
+            (for i in {1..20}; do sleep 60; echo .; done&) && make wait-until-ready
+            (for i in {1..20}; do sleep 60; echo .; done&) &&  make upgrade-oisp DOCKER_TAG=test USE_LOCAL_REGISTRY=true KEYCLOAK_FORCE_MIGRATION="true"
+            kubectl -n oisp scale deployment debugger --replicas=1
+          fi
           make test
           retval=$?
           loops=$((loops+1))

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,14 +8,17 @@ on:
 jobs:
   test:
     uses: Open-IoT-Service-Platform/platform-launcher/.github/workflows/makefile.yaml@develop
+    with:
+      UPGRADE_TEST: "true"
+      CURRENT_RELEASE_VERSION: ${{ secrets.CURRENT_RELEASE_VERSION }}
   build:
     needs: test
     runs-on: ubuntu-20.04
     env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_PREFIX: ${{ secrets.DOCKER_PREFIX }}
-          PUSH_DRYRUN: ''
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_PREFIX: ${{ secrets.DOCKER_PREFIX }}
+      PUSH_DRYRUN: ''
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Implements the upgrade test on top of the nightly cycle and the
e2e test. Step "Set Env" is needed for a workaround to set environmental
variables conditionally.

Signed-off-by: Meric <meric.feyzullahoglu@gmail.com>