### PR TITLE
Change Submodule URLs from HTTPS to SSH Links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,19 +1,19 @@
 [submodule "oisp-frontend"]
 	path = oisp-frontend
-	url = https://github.com/Open-IoT-Service-Platform/oisp-frontend.git
+	url = git@github.com:Open-IoT-Service-Platform/oisp-frontend.git
 [submodule "oisp-backend"]
 	path = oisp-backend
-	url = https://github.com/Open-IoT-Service-Platform/oisp-backend.git
+	url = git@github.com:Open-IoT-Service-Platform/oisp-backend.git
 [submodule "oisp-websocket-server"]
 	path = oisp-websocket-server
-	url = https://github.com/Open-IoT-Service-Platform/oisp-websocket-server.git
+	url = git@github.com:Open-IoT-Service-Platform/oisp-websocket-server.git
 [submodule "oisp-mqtt-gw"]
 	path = oisp-mqtt-gw
-	url = https://github.com/Open-IoT-Service-Platform/oisp-mqtt-gw.git
+	url = git@github.com:Open-IoT-Service-Platform/oisp-mqtt-gw.git
 [submodule "oisp-beam-rule-engine"]
 	path = oisp-beam-rule-engine
-	url = https://github.com/Open-IoT-Service-Platform/oisp-beam-rule-engine.git
+	url = git@github.com:Open-IoT-Service-Platform/oisp-beam-rule-engine.git
 [submodule "oisp-services"]
 	path = oisp-services
-	url = https://github.com/Open-IoT-Service-Platform/oisp-services.git
+	url = git@github.com:Open-IoT-Service-Platform/oisp-services.git
 	branch = develop


### PR DESCRIPTION
Using HTTPS links create issues with pushing to submodules
from the parent repository, because Github doesn't allow
pushing with username and password anymore.

Closes: #580

Signed-off-by: Meric <meric.feyzullahoglu@gmail.com>