### PR TITLE
Update init containers for EMQX and MQTT Gateway

### DIFF
--- a/kubernetes/templates/mqtt.yaml
+++ b/kubernetes/templates/mqtt.yaml
@@ -30,6 +30,21 @@ spec:
       labels:
         app: mqtt-gateway
     spec:
+      initContainers:
+      - name: wait-for-kafka
+        {{ if .Values.use_local_registry }}
+        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        {{ else }}
+        image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        {{ end }}
+        args: [{{ .Values.kafka.service }}, "--", "echo", "kafka is up"]
+      - name: wait-for-emqx
+        {{ if .Values.use_local_registry }}
+        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        {{ else }}
+        image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        {{ end }}
+        args: ["emqx:1883", "--", "echo", "emqx is up"]
       containers:
       - name: mqtt-gateway
         {{ if .Values.use_local_registry }}
@@ -39,14 +54,7 @@ spec:
         {{ end }}
         ports:
         - containerPort: {{ .Values.mqtt.gateway.port }}
-        command: ["./wait-for-it.sh"]
-        args:
-        - redis:6379
-        - -t
-        - "300000"
-        - -s
-        - --
-        - "./start-mqtt-kafka-bridge.sh"
+        command: ["./start-mqtt-kafka-bridge.sh"]
         resources:
           {{ if .Values.less_resources }}
           requests:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -58,6 +58,10 @@ emqx:
     EMQX_LISTENER__SSL__EXTERNAL__CERTFILE: etc/certs/server.cert
     EMQX_LISTENER__SSL__EXTERNAL__KEYFILE: etc/certs/server.key
     EMQX_LISTENER__SSL__EXTERNAL__VERIFY: verify_none
+  initContainers:
+  - name: wait-for-mqtt-auth-service
+    image: oisp/wait-for-it:latest
+    args: ["mqtt-gateway:3025", "--", "echo", "mqtt auth service is up"]
 
 emqxtest:
   replicaCount: 1
@@ -77,6 +81,10 @@ emqxtest:
     EMQX_LISTENER__SSL__EXTERNAL__CERTFILE: etc/certs/server.cert
     EMQX_LISTENER__SSL__EXTERNAL__KEYFILE: etc/certs/server.key
     EMQX_LISTENER__SSL__EXTERNAL__VERIFY: verify_none
+  initContainers:
+  - name: wait-for-mqtt-auth-service
+    image: oisp/wait-for-it:latest
+    args: ["mqtt-gateway:3025", "--", "echo", "mqtt auth service is up"]
 
 
 kafka:

--- a/wait-until-ready.sh
+++ b/wait-until-ready.sh
@@ -95,8 +95,8 @@ check_sts keycloak ${NAMESPACE} 60
 check_deployment frontend ${NAMESPACE} frontend 120
 check_deployment kairosdb ${NAMESPACE} kairosdb 60
 check_deployment websocket-server ${NAMESPACE} websocket-server 60
+check_deployment mqtt-gateway ${NAMESPACE} mqtt-gateway 240
 check_deployment emqx ${NAMESPACE} emqx 240
-check_deployment mqtt-gateway ${NAMESPACE} mqtt-gateway 60
 check_beamservice rule-engine ${NAMESPACE} 240
 printf "\ndone\n"
 exit 0;


### PR DESCRIPTION
- EMQX now waits for MQTT Gateway Auth Service to come up
- MQTT Gateway now waits for kafka to come up
- Tests wait for EMQX and MQTT Gateway longer

closes #586

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>