### PR TITLE
Add image pull credentials to EMQX

### DIFF
--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -18,12 +18,12 @@ dependencies:
   condition: less_resources
 - name: emqx
   alias: emqxtest
-  version: 4.2.6
+  version: 4.2.14
   repository: https://repos.emqx.io/charts
   condition: less_resources
 - name: emqx
   alias: emqx
-  version: 4.2.6
+  version: 4.2.14
   repository: https://repos.emqx.io/charts
   condition: production
 - name: reloader

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -58,6 +58,9 @@ emqx:
     EMQX_LISTENER__SSL__EXTERNAL__CERTFILE: etc/certs/server.cert
     EMQX_LISTENER__SSL__EXTERNAL__KEYFILE: etc/certs/server.key
     EMQX_LISTENER__SSL__EXTERNAL__VERIFY: verify_none
+  image:
+    pullSecrets:
+    - dockercred
   initContainers:
   - name: wait-for-mqtt-auth-service
     image: oisp/wait-for-it:latest
@@ -81,6 +84,9 @@ emqxtest:
     EMQX_LISTENER__SSL__EXTERNAL__CERTFILE: etc/certs/server.cert
     EMQX_LISTENER__SSL__EXTERNAL__KEYFILE: etc/certs/server.key
     EMQX_LISTENER__SSL__EXTERNAL__VERIFY: verify_none
+  image:
+    pullSecrets:
+    - dockercred
   initContainers:
   - name: wait-for-mqtt-auth-service
     image: oisp/wait-for-it:latest


### PR DESCRIPTION
- Minor version update in EMQX to enable support for image credentials
- Required for init containers in EMQX

closes #597

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>