### PR TITLE
Bail after the first failed test during E2E tests

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,7 @@
   "description": "E2E test with server",
   "main": "test.js",
   "scripts": {
-    "test": "mocha oisp-tests.js --exit",
+    "test": "mocha oisp-tests.js --bail --exit",
     "prep-only": "mocha oisp-prep-only.js --exit",
     "test-backup-before": "mocha test-backup-before.js --exit",
     "test-backup-after": "mocha test-backup-after.js --exit"


### PR DESCRIPTION
The --bail flag of mocha added to the test script gives us
intended effect of exiting the E2E test after the first failure
as continuing after that point is usually a waste of time.

Closes: #601 

Signed-off-by: Meric <meric.feyzullahoglu@gmail.com>