### PR TITLE
Add make wait-until-ready command just after the upgrade to nightly w…

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -100,6 +100,7 @@ jobs:
             (for i in {1..20}; do sleep 60; echo .; done&) && make wait-until-ready
             (for i in {1..20}; do sleep 60; echo .; done&) &&  make upgrade-oisp DOCKER_TAG=test USE_LOCAL_REGISTRY=true KEYCLOAK_FORCE_MIGRATION="true"
             kubectl -n oisp scale deployment debugger --replicas=1
+            (for i in {1..20}; do sleep 60; echo .; done&) && make wait-until-ready
           fi
           make test
           retval=$?


### PR DESCRIPTION
…orkflow

The way current upgrade test workflow works causes the ```DEBUGGER_POD```
environment variable to be set with a terminating pod. Adding another
make command just after the upgrade assures that the env will be refreshed
with the ```make test``` command.

Related to: #602

Signed-off-by: Meric Feyzullahoglu <meric.feyzullahoglu@gmail.com>