### PR TITLE
Recreate registry on every workflow run

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -54,6 +54,7 @@ jobs:
           cd util && \
           bash setup-ubuntu20.04.sh
         else
+          make recreate-registry
           make restart-cluster
         fi
     - name: Setup subrepos

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,6 +35,7 @@ jobs:
             cd util && \
             bash setup-ubuntu20.04.sh
           else
+            make recreate-registry
             make restart-cluster
           fi
           

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,13 @@ restart-cluster:
 	@cd util && \
 	./restart-cluster.sh
 
+##	delete and recreate registry, used for the CI setup
+##	needs make restart-cluster command after it
+##
+recreate-registry:
+	@k3d registry delete k3d-oisp.localhost
+	@k3d registry create oisp.localhost -p 12345
+
 # =======
 # TESTING
 # =======


### PR DESCRIPTION
Since we run our workflows on a self hosted environment, we need to
take it into account that if we continue to push new images to our
local registry each run it will fill up and clog the machine. This
commit adds a new makefile command ```make recreate-registry```
which deletes and recreates the local registry and results in a clean
registry each run.

Closes #618 

Signed-off-by: Meric Feyzullahoglu <meric.feyzullahoglu@gmail.com>