### PR TITLE
Make OISP Digital Twin Compliant

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -33,11 +33,14 @@ jobs:
       CURRENT_RELEASE_VERSION: ''
       SELF_HOSTED_RUNNER: true
     runs-on: private
-
     steps:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.ref }}
+    - uses: actions/checkout@v3
+      with:
+        repository: IndustryFusion/DigitalTwin
+        path: ./DigitalTwin
     - name: Set Env
       env:
         CRV: ${{ secrets.CURRENT_RELEASE_VERSION }}
@@ -46,30 +49,48 @@ jobs:
         set +o pipefail
         echo "UPGRADE_TEST=${{ inputs.UPGRADE_TEST }}" >> $GITHUB_ENV
         echo "CURRENT_RELEASE_VERSION=${{ secrets.CURRENT_RELEASE_VERSION }}" >> $GITHUB_ENV
-    - name: Prepare platform
+    - name: Prepare OISP platform
       shell: bash
       run: |
         export TERM=vt100
         if [ -z "${SELF_HOSTED_RUNNER}" ]; then
           cd util && \
           bash setup-ubuntu20.04.sh
-        else
-          make recreate-registry
-          make restart-cluster
         fi
+    - name: Prepare Digital Twin
+      shell: bash
+      run: |
+        if [ -z "${SELF_HOSTED_RUNNER}" ]; then
+          ( cd ./DigitalTwin/test && bash ./prepare-platform.sh )
+        else
+          ( cd ./DigitalTwin/test && bash ./prepare-platform-for-self-hosted-runner.sh )
+        fi
+    - name: Prepare Bats Framework
+      shell: bash
+      run: |
+        cd ./DigitalTwin/test/bats
+        bash ./prepare-test.sh
+        bats linting.bats
+        shellcheck *.sh *.bats test-*/*.bats
+    - name: Build Digital Twin locally
+      shell: bash
+      run: |
+        cd ./DigitalTwin/test && bash build-local-platform.sh
+    - name: Install Digital Twin from local registry
+      shell: bash
+      run: |
+        cd ./DigitalTwin/test && bash install-local-platform.sh
     - name: Setup subrepos
       shell: bash
       run: |
         export TERM=vt100
         git submodule update --recursive --init
         make update
-
-    - name: Build platform
+    - name: Build OISP platform
       run: |
         set +o pipefail
         export TERM=vt100
         yes | DOCKER_TAG=test NODOCKERLOGIN=true DEBUG=true make build
-
     - name: E2E Test
       shell: bash
       run: |

--- a/kubernetes/templates/backend.yaml
+++ b/kubernetes/templates/backend.yaml
@@ -37,14 +37,14 @@ spec:
       initContainers:
       - name: wait-for-kairos
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ end }}
         args: ["kairosdb:8080", "--", "echo", "kariosds is up"]
       - name: wait-for-kafka
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ end }}
@@ -52,7 +52,7 @@ spec:
       containers:
       - name: backend
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/backend:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/backend:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/backend:{{ .Values.tag }}
         {{ end }}

--- a/kubernetes/templates/flink/jobmanager-deployment.yaml
+++ b/kubernetes/templates/flink/jobmanager-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           runAsUser: 9999  # refers to user _flink_ from official flink image, change if necessary
       - name: sql-gateway
          {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/simple-flink-sql-gateway:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/simple-flink-sql-gateway:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/simple-flink-sql-gateway:{{ .Values.tag }}
         {{ end }}

--- a/kubernetes/templates/frontend.yaml
+++ b/kubernetes/templates/frontend.yaml
@@ -44,21 +44,21 @@ spec:
       initContainers:
       - name: wait-for-redis
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ end }}
         args: ["redis:6379", "--", "echo", "redis is up"]
       - name: wait-for-kafka
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ end }}
         args: [{{ .Values.kafka.service }}, "--", "echo", "kafka is up"]
       - name: prepare-db
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
         {{ end }}
@@ -126,14 +126,14 @@ spec:
         args: ["node admin createDB; node admin updateDB"]
       - name: wait-for-keycloak
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ end }}
         args: ["keycloak-http:4080", "--", "echo", "keycloak is up"]
       - name: add-system-users
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
         {{ end }}
@@ -202,7 +202,7 @@ spec:
       containers:
       - name: frontend
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/frontend:{{ .Values.tag }}
         {{ end }}

--- a/kubernetes/templates/grafana.yaml
+++ b/kubernetes/templates/grafana.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: grafana
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/grafana:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/grafana:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/grafana:{{ .Values.tag }}
         {{ end }}

--- a/kubernetes/templates/jobs/emqx-cert-insert.yaml
+++ b/kubernetes/templates/jobs/emqx-cert-insert.yaml
@@ -13,7 +13,7 @@ spec:
       containers:
       - name: emqx-cert-insert
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/backup-service:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/backup-service:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/backup-service:{{ .Values.tag }}
         {{ end }}

--- a/kubernetes/templates/kairosdb.yaml
+++ b/kubernetes/templates/kairosdb.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: kairosdb
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/kairosdb:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/kairosdb:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/kairosdb:{{ .Values.tag }}
         {{ end }}

--- a/kubernetes/templates/mqtt.yaml
+++ b/kubernetes/templates/mqtt.yaml
@@ -33,14 +33,14 @@ spec:
       initContainers:
       - name: wait-for-kafka
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ end }}
         args: [{{ .Values.kafka.service }}, "--", "echo", "kafka is up"]
       - name: wait-for-emqx
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/wait-for-it:{{ .Values.tag }}
         {{ end }}
@@ -48,7 +48,7 @@ spec:
       containers:
       - name: mqtt-gateway
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/mqtt-gateway:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/mqtt-gateway:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/mqtt-gateway:{{ .Values.tag }}
         {{ end }}

--- a/kubernetes/templates/services-operator.yaml
+++ b/kubernetes/templates/services-operator.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: beamservices-operator
       containers:
       {{ if .Values.use_local_registry }}
-      - image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/services-operator:{{ .Values.tag }}
+      - image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/services-operator:{{ .Values.tag }}
       {{ else }}
       - image: {{ .Values.imagePrefix }}/services-operator:{{ .Values.tag }}
       {{ end }}
@@ -114,7 +114,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: beamservices-operator
+  name: beamservices-oisp-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes/templates/services-server.yaml
+++ b/kubernetes/templates/services-server.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       {{ if .Values.use_local_registry }}
-      - image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/services-server:{{ .Values.tag }}
+      - image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/services-server:{{ .Values.tag }}
       {{ else }}
       - image: {{ .Values.imagePrefix }}/services-server:{{ .Values.tag }}
       {{ end }}

--- a/kubernetes/templates/streamer.yaml
+++ b/kubernetes/templates/streamer.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       - name: streamer
       {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/streamer:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/streamer:{{ .Values.tag }}
       {{ else }}
         image: {{ .Values.imagePrefix }}/streamer:{{ .Values.tag }}
       {{ end }}

--- a/kubernetes/templates/test/debugger.yaml
+++ b/kubernetes/templates/test/debugger.yaml
@@ -45,7 +45,7 @@ spec:
       containers:
       - name: debugger
         {{ if .Values.use_local_registry }}
-        image: k3d-oisp.localhost:12345/{{ .Values.imagePrefix }}/debugger:{{ .Values.tag }}
+        image: k3d-iff.localhost:12345/{{ .Values.imagePrefix }}/debugger:{{ .Values.tag }}
         {{ else }}
         image: {{ .Values.imagePrefix }}/debugger:{{ .Values.tag }}
         {{ end }}

--- a/tests/oisp-tests.js
+++ b/tests/oisp-tests.js
@@ -1363,7 +1363,7 @@ describe('Services Operator subtests...'.bold, function() {
     it(descriptions.prepareTestSetup, function(done) {
         test = require('./subtests/services-operator-tests').test(userToken);
         test.prepareTestSetup(done);
-    }).timeout(100000);
+    }).timeout(200000);
     it(descriptions.SendDataToAggregatorAndCheckResult, function(done) {
         test.SendDataToAggregatorAndCheckResult(done);
     }).timeout(10000);

--- a/tests/subtests/rules-and-alerts-tests.js
+++ b/tests/subtests/rules-and-alerts-tests.js
@@ -496,13 +496,13 @@ var test = function(userToken1, userToken2, accountId, deviceId, deviceToken,
         "sendObservationsWithMultipleDevices": function(done) {
             var promises = [];
             promises.push(promtests.checkObservations(temperatureValues, componentId1_1,
-                cbManager2, deviceToken1_1, accountId, deviceId1_1, componentParamName, 0, 60 * 4000));
+                cbManager2, deviceToken1_1, accountId, deviceId1_1, componentParamName, 0, 60 * 6000));
             promises.push(promtests.checkObservations(temperatureValues, componentId1_2,
-                cbManager3, deviceToken1_2, accountId, deviceId1_2, componentParamName, 0, 60 * 4000));
+                cbManager3, deviceToken1_2, accountId, deviceId1_2, componentParamName, 0, 60 * 6000));
             promises.push(promtests.checkObservations(temperatureValues, componentId2_1,
-                cbManager4, deviceToken2_1, accountId2, deviceId2_1, componentParamName, 0, 60 * 4000));
+                cbManager4, deviceToken2_1, accountId2, deviceId2_1, componentParamName, 0, 60 * 6000));
             promises.push(promtests.checkObservations(temperatureValues2, componentId2_2,
-                cbManager5, deviceToken2_2, accountId2, deviceId2_2, componentParamName, 0, 60 * 4000));
+                cbManager5, deviceToken2_2, accountId2, deviceId2_2, componentParamName, 0, 60 * 6000));
             Promise.all(promises)
                 .then(() => { done(); })
                 .catch((err) => { done(err); });

--- a/util/restart-cluster.sh
+++ b/util/restart-cluster.sh
@@ -9,7 +9,7 @@ then
 fi
 
 k3d cluster delete ${CLUSTERNAME} || echo "Cluster ${CLUSTERNAME} could not be deleted/ does not exist"
-k3d cluster create ${CLUSTERNAME} --registry-use k3d-oisp.localhost:12345 --image=${K3S_IMAGE}
+k3d cluster create ${CLUSTERNAME} --registry-use iff.localhost.12345 --image=${K3S_IMAGE}
 
 printf "\033[1mKubernetes cluster started\033[0m\n"
 kubectl cluster-info

--- a/util/setup-ubuntu20.04.sh
+++ b/util/setup-ubuntu20.04.sh
@@ -37,10 +37,10 @@ printf "\n"
 
 printf "\033[1mInstalling k3d docker repo\n"
 printf -- "-----------------------\033[0m\n"
-k3d registry create oisp.localhost -p 12345
+k3d registry create iff.localhost -p 12345
 echo "Adding to /etc/hosts:"
 echo "" | sudo tee -a /etc/hosts
-echo "127.0.0.1 k3d-oisp.localhost" | sudo tee -a /etc/hosts
+echo "127.0.0.1 k3d-iff.localhost" | sudo tee -a /etc/hosts
 
 
 printf "\033[1mInstalling kubectl\n"

--- a/wait-until-ready.sh
+++ b/wait-until-ready.sh
@@ -66,7 +66,7 @@ function check_beamservice {
   local counts_max=$3
   local counts_actual=0
   printf "\nWaiting for $name"
-  until (kubectl -n $namespace get bs rule-engine -o yaml | grep "state: RUNNING");
+  until (kubectl -n $namespace get "beamservices.${namespace}.org" rule-engine -o yaml | grep "state: RUNNING");
     do printf "."
     let counts_actual=$counts_actual+1;
     if [ $counts_actual -ge $counts_max ];


### PR DESCRIPTION
- OISP can now be deployed after Digital Twin
- OISP can still be deployed standalone, will be removed in future
- CI E2E PR tests deploy IFF first
- Nightly tests remain unchanged

related to #650

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>