### PR TITLE
Disable Continuous Deployment to latest.oisp

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -86,31 +86,31 @@ jobs:
               echo Only dry run mode. Not pushing to dockerhub!
             fi
           done
-  docker-action:
-    needs: build
-    env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      NAMESPACE: ${{ secrets.NAMESPACE }}
-    runs-on: private
-    container:
-      image: oisp/deployer:latest
-      credentials:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+  # docker-action:
+  #   needs: build
+  #   env:
+  #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  #     NAMESPACE: ${{ secrets.NAMESPACE }}
+  #   runs-on: private
+  #   container:
+  #     image: oisp/deployer:latest
+  #     credentials:
+  #       username: ${{ secrets.DOCKER_USERNAME }}
+  #       password: ${{ secrets.DOCKER_PASSWORD }}
 
-    steps:
-      - name: Deploy Test
-        run: |
-          export TERM=vt100
-          export HOME=/home/deployer
-          cd /home/deployer
-          export KUBECONFIG=/home/deployer/.kube/config
-          export HELM_ARGS="--atomic \
-            --set less_resources=\"false\" --set production=\"true\" \
-            --set certmanager.secret=\"frontend-web-prod-tls\" \
-            --set certmanager.issuer=\"letsencrypt-prod\" \
-            --set numberReplicas.frontend=2 \
-            --set numberReplicas.backend=3"
-          sh deploy.sh
+  #   steps:
+  #     - name: Deploy Test
+  #       run: |
+  #         export TERM=vt100
+  #         export HOME=/home/deployer
+  #         cd /home/deployer
+  #         export KUBECONFIG=/home/deployer/.kube/config
+  #         export HELM_ARGS="--atomic \
+  #           --set less_resources=\"false\" --set production=\"true\" \
+  #           --set certmanager.secret=\"frontend-web-prod-tls\" \
+  #           --set certmanager.issuer=\"letsencrypt-prod\" \
+  #           --set numberReplicas.frontend=2 \
+  #           --set numberReplicas.backend=3"
+  #         sh deploy.sh
 


### PR DESCRIPTION
latest.oisp is currently offline therefore CD is disabled until its integration with Digital Twin is enhanced and upgrade tests for Digital Twin are created.

Closes: #717